### PR TITLE
FEAT: 네트워크 계층 설계 및 구현 

### DIFF
--- a/Network/Base/HTTPHeaderField.swift
+++ b/Network/Base/HTTPHeaderField.swift
@@ -1,0 +1,19 @@
+//
+//  HTTPHeaderField.swift
+//  QRIZ
+//
+//  Created by KSH on 12/15/24.
+//
+
+import Foundation
+
+enum HTTPHeaderField: String {
+    case contentType = "Content-Type"
+    case authentication = "Authorization"
+    case refreshToken = "Refresh-Token"
+    case acceptType = "Accept"
+}
+
+enum ContentType: String {
+    case json = "Application/json"
+}

--- a/Network/Base/HTTPMethod.swift
+++ b/Network/Base/HTTPMethod.swift
@@ -1,0 +1,14 @@
+//
+//  HTTPMethod.swift
+//  QRIZ
+//
+//  Created by KSH on 12/15/24.
+//
+
+import Foundation
+
+enum HTTPMethod: String {
+    case get = "GET"
+    case post = "POST"
+    case delete = "DELETE"
+}

--- a/Network/Base/Network.swift
+++ b/Network/Base/Network.swift
@@ -1,0 +1,85 @@
+//
+//  Network.swift
+//  QRIZ
+//
+//  Created by KSH on 12/18/24.
+//
+
+import Foundation
+import Combine
+
+protocol Network {
+    func send<T: Request>(_ request: T) -> AnyPublisher<T.Response, NetworkError>
+    func sendAsync<T: Request>(_ request: T) async throws -> T.Response
+}
+
+final class NetworkImp: Network {
+    
+    private let session: URLSession
+    
+    init(session: URLSession) {
+        self.session = session
+    }
+    
+    func send<T>(_ request: T) -> AnyPublisher<T.Response, NetworkError> where T: Request {
+        guard let urlRequest = try? RequestFactory(request: request).urlRequestRepresentation() else {
+            return Fail(error: NetworkError.invalidURL(message: "URL 생성에 실패했습니다."))
+                .eraseToAnyPublisher()
+        }
+        
+        return session.dataTaskPublisher(for: urlRequest)
+            .tryMap { data, response in
+                try self.validate(response)
+                return data
+            }
+            .decode(type: T.Response.self, decoder: JSONDecoder())
+            .mapError { self.mapToNetworkError($0) }
+            .eraseToAnyPublisher()
+    }
+    
+    func sendAsync<T>(_ request: T) async throws -> T.Response where T: Request {
+        do {
+            let urlRequest = try RequestFactory(request: request).urlRequestRepresentation()
+            let (data, response) = try await session.data(for: urlRequest)
+            
+            try validate(response)
+            return try JSONDecoder().decode(T.Response.self, from: data)
+        } catch let error {
+            throw mapToNetworkError(error)
+        }
+    }
+}
+
+extension NetworkImp {
+    private func validate(_ response: URLResponse) throws {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.unknownError
+        }
+        
+        switch httpResponse.statusCode {
+        case 200..<300: return
+        case 400..<500: throw NetworkError.clientError(
+            code: httpResponse.statusCode,
+            message: "클라이언트 에러입니다."
+        )
+        case 500..<600: throw NetworkError.serverError
+        default: throw NetworkError.unknownError
+        }
+    }
+    
+    private func mapToNetworkError(_ error: Error) -> NetworkError {
+        if let networkError = error as? NetworkError {
+            return networkError
+        }
+        
+        if let urlError = error as? URLError {
+            return .invalidURL(message: urlError.localizedDescription)
+        }
+        
+        if error is DecodingError {
+            return .jsonDecodingError
+        }
+        
+        return .unknownError
+    }
+}

--- a/Network/Base/NetworkError.swift
+++ b/Network/Base/NetworkError.swift
@@ -8,21 +8,25 @@
 import Foundation
 
 enum NetworkError: Error {
+    /** URL 생성 실패 */ case invalidURL(message: String)
     /** URL Encoding 에러*/ case urlEncodingError
     /** JSON Decoding 에러*/ case jsonDecodingError
     /** 토큰 만료 시 에러*/ case unAuthorizedError
-    /** 클라이언트 에러*/ case clientError(code: String, message: String)
+    /** 클라이언트 에러*/ case clientError(code: Int, message: String)
     /** 서버 에러*/ case serverError
+    /** 알 수 없는 에러*/ case unknownError
 }
 
 extension NetworkError {
     var description: String {
         switch self {
+        case .invalidURL(let message): return "유효하지 않은 URL입니다. \(message)"
         case .urlEncodingError: return "URL Encoding 에러입니다."
         case .jsonDecodingError: return "JSON Decoding 에러입니다."
         case .unAuthorizedError: return "접근 권한이 없습니다."
         case .clientError(let code, let message): return "클라이언트 에러 code: \(code), message:\(message)"
         case .serverError: return "서버 에러."
+        case .unknownError: return "알 수 없는 오류입니다."
         }
     }
 }

--- a/Network/Base/NetworkError.swift
+++ b/Network/Base/NetworkError.swift
@@ -1,0 +1,28 @@
+//
+//  NetworkError.swift
+//  QRIZ
+//
+//  Created by KSH on 12/15/24.
+//
+
+import Foundation
+
+enum NetworkError: Error {
+    /** URL Encoding 에러*/ case urlEncodingError
+    /** JSON Decoding 에러*/ case jsonDecodingError
+    /** 토큰 만료 시 에러*/ case unAuthorizedError
+    /** 클라이언트 에러*/ case clientError(code: String, message: String)
+    /** 서버 에러*/ case serverError
+}
+
+extension NetworkError {
+    var description: String {
+        switch self {
+        case .urlEncodingError: return "URL Encoding 에러입니다."
+        case .jsonDecodingError: return "JSON Decoding 에러입니다."
+        case .unAuthorizedError: return "접근 권한이 없습니다."
+        case .clientError(let code, let message): return "클라이언트 에러 code: \(code), message:\(message)"
+        case .serverError: return "서버 에러."
+        }
+    }
+}

--- a/Network/Base/NetworkRequest.swift
+++ b/Network/Base/NetworkRequest.swift
@@ -1,0 +1,83 @@
+//
+//  NetworkRequest.swift
+//  QRIZ
+//
+//  Created by KSH on 12/18/24.
+//
+
+import Foundation
+
+typealias QueryItems = [String: String]
+typealias HTTPHeader = [String: String]
+
+protocol Request {
+    associatedtype Response: Decodable
+    
+    var baseURL: URL { get }
+    var path: String { get }
+    var method: HTTPMethod { get }
+    var query: QueryItems { get }
+    var headers: HTTPHeader { get }
+}
+
+extension Request {
+    /// 임시 URL입니다.
+    var baseURL: URL {
+        return URL(string: "https://jsonplaceholder.typicode.com")!
+    }
+    
+    var query: QueryItems { [:] }
+    var headers: HTTPHeader { [:] }
+    
+    var endpoint: URL {
+        return baseURL.appendingPathComponent(path)
+    }
+}
+
+
+final class RequestFactory<T: Request> {
+    
+    private let request: T
+    private var urlComponents: URLComponents?
+    
+    init(request: T) {
+        self.request = request
+        self.urlComponents = URLComponents(url: request.endpoint, resolvingAgainstBaseURL: true)
+    }
+    
+    func urlRequestRepresentation() throws -> URLRequest {
+        switch request.method {
+        case .get, .delete:
+            return try makeGetRequest()
+        case .post:
+            return try makePostRequest()
+        }
+    }
+    
+    private func makeGetRequest() throws -> URLRequest {
+        if request.query.isEmpty == false {
+            urlComponents?.queryItems = request.query.map {
+                URLQueryItem(name: $0.key, value: "\($0.value)") }
+        }
+        return try makeURLRequest()
+    }
+    
+    private func makePostRequest() throws -> URLRequest {
+        let body = try JSONSerialization.data(withJSONObject: request.query, options: [])
+        return try makeURLRequest(httpBody: body)
+    }
+    
+    private func makeURLRequest(httpBody: Data? = nil) throws -> URLRequest {
+        guard let url = urlComponents?.url else {
+            throw NetworkError.invalidURL(message: "URL 생성에 실패했습니다. endpoint: \(request.endpoint), query: \(request.query)")
+        }
+        
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = request.method.rawValue
+        request.headers.forEach { urlRequest.setValue($0.value, forHTTPHeaderField: $0.key) }
+        urlRequest.httpBody = httpBody
+        return urlRequest
+    }
+}
+
+

--- a/Network/DTOs/Example/ExampleRequest.swift
+++ b/Network/DTOs/Example/ExampleRequest.swift
@@ -1,0 +1,15 @@
+//
+//  ExampleRequest.swift
+//  QRIZ
+//
+//  Created by KSH on 12/18/24.
+//
+
+import Foundation
+
+struct ExampleRequest: Request {
+    typealias Response = ExampleResponse
+    
+    var path: String { "/todos/1" }
+    var method: HTTPMethod { .get }
+}

--- a/Network/DTOs/Example/ExampleResponse.swift
+++ b/Network/DTOs/Example/ExampleResponse.swift
@@ -1,0 +1,15 @@
+//
+//  ExampleResponse.swift
+//  QRIZ
+//
+//  Created by KSH on 12/18/24.
+//
+
+import Foundation
+
+struct ExampleResponse: Decodable {
+    let userId: Int
+    let id: Int
+    let title: String
+    let completed: Bool
+}

--- a/Network/Service/ExampleService.swift
+++ b/Network/Service/ExampleService.swift
@@ -1,0 +1,45 @@
+//
+//  ExampleService.swift
+//  QRIZ
+//
+//  Created by KSH on 12/18/24.
+//
+
+import Foundation
+import Combine
+
+protocol ExampleServiceProtocol {
+    func fetchData() -> AnyPublisher<ExampleResponse, NetworkError>
+    func fetchDataAsync() async -> Result<ExampleResponse, NetworkError>
+}
+
+final class ExampleService: ExampleServiceProtocol {
+    
+    private let network: Network
+    
+    init(network: Network) {
+        self.network = network
+    }
+    
+    func fetchData() -> AnyPublisher<ExampleResponse, NetworkError> {
+        let request = ExampleRequest()
+        return network.send(request)
+    }
+    
+    func fetchDataAsync() async -> Result<ExampleResponse, NetworkError> {
+        do {
+            let request = ExampleRequest()
+            let response = try await network.sendAsync(request)
+            return .success(response)
+        } catch let error as NetworkError {
+            return .failure(error)
+        } catch {
+            return .failure(.unknownError)
+        }
+    }
+    
+    func fetchDataAsync() async throws -> ExampleResponse {
+        let request = ExampleRequest()
+        return try await network.sendAsync(request)
+    }
+}

--- a/Network/Service/ExampleService.swift
+++ b/Network/Service/ExampleService.swift
@@ -9,8 +9,7 @@ import Foundation
 import Combine
 
 protocol ExampleServiceProtocol {
-    func fetchData() -> AnyPublisher<ExampleResponse, NetworkError>
-    func fetchDataAsync() async -> Result<ExampleResponse, NetworkError>
+    func fetchData() async throws -> ExampleResponse
 }
 
 final class ExampleService: ExampleServiceProtocol {
@@ -21,25 +20,8 @@ final class ExampleService: ExampleServiceProtocol {
         self.network = network
     }
     
-    func fetchData() -> AnyPublisher<ExampleResponse, NetworkError> {
+    func fetchData() async throws -> ExampleResponse {
         let request = ExampleRequest()
-        return network.send(request)
-    }
-    
-    func fetchDataAsync() async -> Result<ExampleResponse, NetworkError> {
-        do {
-            let request = ExampleRequest()
-            let response = try await network.sendAsync(request)
-            return .success(response)
-        } catch let error as NetworkError {
-            return .failure(error)
-        } catch {
-            return .failure(.unknownError)
-        }
-    }
-    
-    func fetchDataAsync() async throws -> ExampleResponse {
-        let request = ExampleRequest()
-        return try await network.sendAsync(request)
+        return try await network.send(request)
     }
 }

--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		541878542D0E21620089F478 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541878532D0E21620089F478 /* HTTPMethod.swift */; };
 		541878572D0E22700089F478 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541878562D0E22700089F478 /* NetworkError.swift */; };
+		541878612D0EC2970089F478 /* HTTPHeaderField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541878602D0EC2970089F478 /* HTTPHeaderField.swift */; };
 		54DB0D992D0950DE00ABD458 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB0D982D0950DE00ABD458 /* ViewModel.swift */; };
 		54DB0D9D2D09513300ABD458 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB0D9C2D09513300ABD458 /* AppCoordinator.swift */; };
 		54DB0DA12D0951C000ABD458 /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB0DA02D0951C000ABD458 /* Font+.swift */; };
@@ -49,6 +50,7 @@
 /* Begin PBXFileReference section */
 		541878532D0E21620089F478 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		541878562D0E22700089F478 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		541878602D0EC2970089F478 /* HTTPHeaderField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeaderField.swift; sourceTree = "<group>"; };
 		54DB0D982D0950DE00ABD458 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		54DB0D9C2D09513300ABD458 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		54DB0DA02D0951C000ABD458 /* Font+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+.swift"; sourceTree = "<group>"; };
@@ -112,6 +114,7 @@
 			children = (
 				541878532D0E21620089F478 /* HTTPMethod.swift */,
 				541878562D0E22700089F478 /* NetworkError.swift */,
+				541878602D0EC2970089F478 /* HTTPHeaderField.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -402,6 +405,7 @@
 				E23963092D083B900092B39B /* AppDelegate.swift in Sources */,
 				54DB0D9D2D09513300ABD458 /* AppCoordinator.swift in Sources */,
 				54DB0D992D0950DE00ABD458 /* ViewModel.swift in Sources */,
+				541878612D0EC2970089F478 /* HTTPHeaderField.swift in Sources */,
 				E239630B2D083B900092B39B /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		541878572D0E22700089F478 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541878562D0E22700089F478 /* NetworkError.swift */; };
 		541878612D0EC2970089F478 /* HTTPHeaderField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541878602D0EC2970089F478 /* HTTPHeaderField.swift */; };
 		548566492D123C94002BAEE3 /* NetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548566482D123C94002BAEE3 /* NetworkRequest.swift */; };
+		5485664B2D123FC2002BAEE3 /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5485664A2D123FC2002BAEE3 /* Network.swift */; };
 		54DB0D992D0950DE00ABD458 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB0D982D0950DE00ABD458 /* ViewModel.swift */; };
 		54DB0D9D2D09513300ABD458 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB0D9C2D09513300ABD458 /* AppCoordinator.swift */; };
 		54DB0DA12D0951C000ABD458 /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB0DA02D0951C000ABD458 /* Font+.swift */; };
@@ -53,6 +54,7 @@
 		541878562D0E22700089F478 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		541878602D0EC2970089F478 /* HTTPHeaderField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeaderField.swift; sourceTree = "<group>"; };
 		548566482D123C94002BAEE3 /* NetworkRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRequest.swift; sourceTree = "<group>"; };
+		5485664A2D123FC2002BAEE3 /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
 		54DB0D982D0950DE00ABD458 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		54DB0D9C2D09513300ABD458 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		54DB0DA02D0951C000ABD458 /* Font+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+.swift"; sourceTree = "<group>"; };
@@ -118,6 +120,7 @@
 				541878562D0E22700089F478 /* NetworkError.swift */,
 				541878602D0EC2970089F478 /* HTTPHeaderField.swift */,
 				548566482D123C94002BAEE3 /* NetworkRequest.swift */,
+				5485664A2D123FC2002BAEE3 /* Network.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -406,6 +409,7 @@
 				E239630D2D083B900092B39B /* ViewController.swift in Sources */,
 				541878542D0E21620089F478 /* HTTPMethod.swift in Sources */,
 				548566492D123C94002BAEE3 /* NetworkRequest.swift in Sources */,
+				5485664B2D123FC2002BAEE3 /* Network.swift in Sources */,
 				E23963092D083B900092B39B /* AppDelegate.swift in Sources */,
 				54DB0D9D2D09513300ABD458 /* AppCoordinator.swift in Sources */,
 				54DB0D992D0950DE00ABD458 /* ViewModel.swift in Sources */,

--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		541878542D0E21620089F478 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541878532D0E21620089F478 /* HTTPMethod.swift */; };
+		541878572D0E22700089F478 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541878562D0E22700089F478 /* NetworkError.swift */; };
 		54DB0D992D0950DE00ABD458 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB0D982D0950DE00ABD458 /* ViewModel.swift */; };
 		54DB0D9D2D09513300ABD458 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB0D9C2D09513300ABD458 /* AppCoordinator.swift */; };
 		54DB0DA12D0951C000ABD458 /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB0DA02D0951C000ABD458 /* Font+.swift */; };
@@ -47,6 +48,7 @@
 
 /* Begin PBXFileReference section */
 		541878532D0E21620089F478 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
+		541878562D0E22700089F478 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		54DB0D982D0950DE00ABD458 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		54DB0D9C2D09513300ABD458 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		54DB0DA02D0951C000ABD458 /* Font+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+.swift"; sourceTree = "<group>"; };
@@ -109,6 +111,7 @@
 			isa = PBXGroup;
 			children = (
 				541878532D0E21620089F478 /* HTTPMethod.swift */,
+				541878562D0E22700089F478 /* NetworkError.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -393,6 +396,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				54DB0DA12D0951C000ABD458 /* Font+.swift in Sources */,
+				541878572D0E22700089F478 /* NetworkError.swift in Sources */,
 				E239630D2D083B900092B39B /* ViewController.swift in Sources */,
 				541878542D0E21620089F478 /* HTTPMethod.swift in Sources */,
 				E23963092D083B900092B39B /* AppDelegate.swift in Sources */,

--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		541878542D0E21620089F478 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541878532D0E21620089F478 /* HTTPMethod.swift */; };
 		541878572D0E22700089F478 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541878562D0E22700089F478 /* NetworkError.swift */; };
 		541878612D0EC2970089F478 /* HTTPHeaderField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541878602D0EC2970089F478 /* HTTPHeaderField.swift */; };
+		548566492D123C94002BAEE3 /* NetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548566482D123C94002BAEE3 /* NetworkRequest.swift */; };
 		54DB0D992D0950DE00ABD458 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB0D982D0950DE00ABD458 /* ViewModel.swift */; };
 		54DB0D9D2D09513300ABD458 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB0D9C2D09513300ABD458 /* AppCoordinator.swift */; };
 		54DB0DA12D0951C000ABD458 /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB0DA02D0951C000ABD458 /* Font+.swift */; };
@@ -51,6 +52,7 @@
 		541878532D0E21620089F478 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		541878562D0E22700089F478 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		541878602D0EC2970089F478 /* HTTPHeaderField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeaderField.swift; sourceTree = "<group>"; };
+		548566482D123C94002BAEE3 /* NetworkRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRequest.swift; sourceTree = "<group>"; };
 		54DB0D982D0950DE00ABD458 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		54DB0D9C2D09513300ABD458 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		54DB0DA02D0951C000ABD458 /* Font+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+.swift"; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 				541878532D0E21620089F478 /* HTTPMethod.swift */,
 				541878562D0E22700089F478 /* NetworkError.swift */,
 				541878602D0EC2970089F478 /* HTTPHeaderField.swift */,
+				548566482D123C94002BAEE3 /* NetworkRequest.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -402,6 +405,7 @@
 				541878572D0E22700089F478 /* NetworkError.swift in Sources */,
 				E239630D2D083B900092B39B /* ViewController.swift in Sources */,
 				541878542D0E21620089F478 /* HTTPMethod.swift in Sources */,
+				548566492D123C94002BAEE3 /* NetworkRequest.swift in Sources */,
 				E23963092D083B900092B39B /* AppDelegate.swift in Sources */,
 				54DB0D9D2D09513300ABD458 /* AppCoordinator.swift in Sources */,
 				54DB0D992D0950DE00ABD458 /* ViewModel.swift in Sources */,

--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		541878542D0E21620089F478 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541878532D0E21620089F478 /* HTTPMethod.swift */; };
 		54DB0D992D0950DE00ABD458 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB0D982D0950DE00ABD458 /* ViewModel.swift */; };
 		54DB0D9D2D09513300ABD458 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB0D9C2D09513300ABD458 /* AppCoordinator.swift */; };
 		54DB0DA12D0951C000ABD458 /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB0DA02D0951C000ABD458 /* Font+.swift */; };
@@ -45,6 +46,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		541878532D0E21620089F478 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		54DB0D982D0950DE00ABD458 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		54DB0D9C2D09513300ABD458 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		54DB0DA02D0951C000ABD458 /* Font+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+.swift"; sourceTree = "<group>"; };
@@ -95,6 +97,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		541878522D0E21250089F478 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				541878552D0E22080089F478 /* Base */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		541878552D0E22080089F478 /* Base */ = {
+			isa = PBXGroup;
+			children = (
+				541878532D0E21620089F478 /* HTTPMethod.swift */,
+			);
+			path = Base;
+			sourceTree = "<group>";
+		};
 		54DB0D952D094FAA00ABD458 /* App */ = {
 			isa = PBXGroup;
 			children = (
@@ -165,6 +183,7 @@
 		E23962FC2D083B8F0092B39B = {
 			isa = PBXGroup;
 			children = (
+				541878522D0E21250089F478 /* Network */,
 				E23963072D083B8F0092B39B /* QRIZ */,
 				E239631E2D083B910092B39B /* QRIZTests */,
 				E23963282D083B910092B39B /* QRIZUITests */,
@@ -375,6 +394,7 @@
 			files = (
 				54DB0DA12D0951C000ABD458 /* Font+.swift in Sources */,
 				E239630D2D083B900092B39B /* ViewController.swift in Sources */,
+				541878542D0E21620089F478 /* HTTPMethod.swift in Sources */,
 				E23963092D083B900092B39B /* AppDelegate.swift in Sources */,
 				54DB0D9D2D09513300ABD458 /* AppCoordinator.swift in Sources */,
 				54DB0D992D0950DE00ABD458 /* ViewModel.swift in Sources */,

--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		541878612D0EC2970089F478 /* HTTPHeaderField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541878602D0EC2970089F478 /* HTTPHeaderField.swift */; };
 		548566492D123C94002BAEE3 /* NetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548566482D123C94002BAEE3 /* NetworkRequest.swift */; };
 		5485664B2D123FC2002BAEE3 /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5485664A2D123FC2002BAEE3 /* Network.swift */; };
+		548566502D1241A4002BAEE3 /* ExampleRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5485664F2D1241A4002BAEE3 /* ExampleRequest.swift */; };
+		548566522D1241BA002BAEE3 /* ExampleResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548566512D1241BA002BAEE3 /* ExampleResponse.swift */; };
+		548566552D124260002BAEE3 /* ExampleService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548566542D124260002BAEE3 /* ExampleService.swift */; };
 		54DB0D992D0950DE00ABD458 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB0D982D0950DE00ABD458 /* ViewModel.swift */; };
 		54DB0D9D2D09513300ABD458 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB0D9C2D09513300ABD458 /* AppCoordinator.swift */; };
 		54DB0DA12D0951C000ABD458 /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54DB0DA02D0951C000ABD458 /* Font+.swift */; };
@@ -55,6 +58,9 @@
 		541878602D0EC2970089F478 /* HTTPHeaderField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeaderField.swift; sourceTree = "<group>"; };
 		548566482D123C94002BAEE3 /* NetworkRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRequest.swift; sourceTree = "<group>"; };
 		5485664A2D123FC2002BAEE3 /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
+		5485664F2D1241A4002BAEE3 /* ExampleRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleRequest.swift; sourceTree = "<group>"; };
+		548566512D1241BA002BAEE3 /* ExampleResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleResponse.swift; sourceTree = "<group>"; };
+		548566542D124260002BAEE3 /* ExampleService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleService.swift; sourceTree = "<group>"; };
 		54DB0D982D0950DE00ABD458 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		54DB0D9C2D09513300ABD458 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		54DB0DA02D0951C000ABD458 /* Font+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+.swift"; sourceTree = "<group>"; };
@@ -109,6 +115,8 @@
 			isa = PBXGroup;
 			children = (
 				541878552D0E22080089F478 /* Base */,
+				5485664D2D12411F002BAEE3 /* DTOs */,
+				548566532D1241CB002BAEE3 /* Service */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -123,6 +131,31 @@
 				5485664A2D123FC2002BAEE3 /* Network.swift */,
 			);
 			path = Base;
+			sourceTree = "<group>";
+		};
+		5485664D2D12411F002BAEE3 /* DTOs */ = {
+			isa = PBXGroup;
+			children = (
+				5485664E2D124150002BAEE3 /* Example */,
+			);
+			path = DTOs;
+			sourceTree = "<group>";
+		};
+		5485664E2D124150002BAEE3 /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				5485664F2D1241A4002BAEE3 /* ExampleRequest.swift */,
+				548566512D1241BA002BAEE3 /* ExampleResponse.swift */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		548566532D1241CB002BAEE3 /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				548566542D124260002BAEE3 /* ExampleService.swift */,
+			);
+			path = Service;
 			sourceTree = "<group>";
 		};
 		54DB0D952D094FAA00ABD458 /* App */ = {
@@ -408,12 +441,15 @@
 				541878572D0E22700089F478 /* NetworkError.swift in Sources */,
 				E239630D2D083B900092B39B /* ViewController.swift in Sources */,
 				541878542D0E21620089F478 /* HTTPMethod.swift in Sources */,
+				548566502D1241A4002BAEE3 /* ExampleRequest.swift in Sources */,
+				548566522D1241BA002BAEE3 /* ExampleResponse.swift in Sources */,
 				548566492D123C94002BAEE3 /* NetworkRequest.swift in Sources */,
 				5485664B2D123FC2002BAEE3 /* Network.swift in Sources */,
 				E23963092D083B900092B39B /* AppDelegate.swift in Sources */,
 				54DB0D9D2D09513300ABD458 /* AppCoordinator.swift in Sources */,
 				54DB0D992D0950DE00ABD458 /* ViewModel.swift in Sources */,
 				541878612D0EC2970089F478 /* HTTPHeaderField.swift in Sources */,
+				548566552D124260002BAEE3 /* ExampleService.swift in Sources */,
 				E239630B2D083B900092B39B /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## 🛠️ Task

- 네트워크 로직 구현

## 🌱 PR Point

# 네트워킹 코드 추상화를 해보자!(feat: asnyc/await)

새 프로젝트를 시작하면서 기존에 사용하던 Completionhandler로 구현된 네트워킹 코드를 버리고 새롭게 asnyc/await으로 구현할 겸 겸사겸사 추상화도 해보겠슴다ㅇㅇ!

흠 일단 iOS에서 REST API 처리 과정을 한번 봅시다!
![RestApiModel2](https://github.com/user-attachments/assets/c2f7e539-f997-40cb-9cc0-c202a9684d37)


그림을 보면 알 수 있듯이 REST API를 주고받는 과정에서 iOS에서 처리해야 할 작업을 크게 3개로 나눠서 구현을 해보겠습니다.
#### 1. Request 구성
#### 2. Request 전달
#### 3. 서버에서 받은 데이터 Decoding
#### 이제 각 단계별로 하나씩 구현을 해보겠습니다.

## 1. Request 구성
### 1-1. Request 프로토콜 정의
```swift
typealias QueryItems = [String: String]
typealias HTTPHeader = [String: String]

protocol Request {
    associatedtype Response: Decodable
    
    var baseURL: URL { get }
    var path: String { get }
    var method: HTTPMethod { get }
    var query: QueryItems { get }
    var headers: HTTPHeader { get }
}

extension Request {
    /// 임시 URL입니다.
    var baseURL: URL {
        return URL(string: "https://jsonplaceholder.typicode.com")!
    }
    
    var query: QueryItems { [:] }
    var headers: HTTPHeader { [:] }
    
    var endpoint: URL {
        return baseURL.appendingPathComponent(path)
    }
}
```
#### 프로토콜 선언 이유
- 프로젝트 규모가 커지고 API가 많아지면 관리가 복잡해지는데 프로토콜로 정의하면 `필요한 부분만 쉽게 수정하거나 데이터를 추가 요청하는 등 유지보수가 편해짐` + `일관성 덕분에 여러 API를 보더라도 가독성 있게 관리`할 수 있기에 프로토콜을 정의해줬습니다.
#### `associatedtype Response: Decodable`을 넣은 이유
- 나중에 요청을 보낼 때 해당 요청에 맞는 응답을 명확하게 전달할 수 있도록 Request에 Decodable을 채택한 Response를 선언하여 요청과 응답을 커플로 쉽게 관리할 수 있게 하기 위해서 추가했습니다.
#### extension에 선언한 프로퍼티는 왜?
- `baseURL`: 환경(개발, 테스트, 배포)변화에 따라 주입받는 방식도 고려했지만 이번 프로젝트에서는 baseURL이 변경될 일이 없으므로 `편의성`을 중점으로 두고 extension에 고정적으로 구현했습니다.
- `query`와 `headers`: 요청마다 필요 여부가 달라집니다. 불필요하게 선언하는 번거로움을 줄이기 위해서 기본값을 빈값으로 설정해 필요할 때만 구현할 수 있도록 했습니다.
- `endpoint`: 나중에 RequestFactory에서 URL을 쉽게 생성하기 위해 선언해둔 프로퍼티입니다.

### 1-2. Request 조합기
- RequestFactory 클래스는 `Request` 프로토콜을 채택한 객체를 `URLRequest`로 만들어주는 클래스입니다.
- 요청의 HTTP 메서드에 따라 적절한 URLRequest를 구성 후 `makeURLRequest()`에서 최종 URLRequest를 생성하고 반환해줍니다.
- 이를 통해서 다양한 request객체를 `RequestFactory`를 통해서 효율적으로 처리할 수 있어 `재사용`과 `유지보수`에 큰 도움이 되어줍니다.
```swift
final class RequestFactory<T: Request> {
    
    private let request: T
    private var urlComponents: URLComponents?
    
    init(request: T) {
        self.request = request
        self.urlComponents = URLComponents(url: request.endpoint, resolvingAgainstBaseURL: true)
    }
    
    func urlRequestRepresentation() throws -> URLRequest {
        switch request.method {
        case .get, .delete:
            return try makeGetRequest()
        case .post:
            return try makePostRequest()
        }
    }
    
    private func makeGetRequest() throws -> URLRequest {
        if request.query.isEmpty == false {
            urlComponents?.queryItems = request.query.map {
                URLQueryItem(name: $0.key, value: "\($0.value)") }
        }
        return try makeURLRequest()
    }
    
    private func makePostRequest() throws -> URLRequest {
        let body = try JSONSerialization.data(withJSONObject: request.query, options: [])
        return try makeURLRequest(httpBody: body)
    }
    
    private func makeURLRequest(httpBody: Data? = nil) throws -> URLRequest {
        guard let url = urlComponents?.url else {
            throw NetworkError.invalidURL(message: "URL 생성에 실패했습니다. endpoint: \(request.endpoint), query: \(request.query)")
        }
        
        var urlRequest = URLRequest(url: url)
        urlRequest.httpMethod = request.method.rawValue
        request.headers.forEach { urlRequest.setValue($0.value, forHTTPHeaderField: $0.key) }
        urlRequest.httpBody = httpBody
        return urlRequest
    }
}
```
#### HTTP 메서드에 따른 `QueryItems`의 역할
- GET
    - `QueryItems`는 쿼리 파라미터를 구성하는데 사용이 됩니다.
    - https://www.asadf.com/resource?param1=value1&param2=value2 처럼 URL에 포함되어 서버에 전달 가능한 구조입니다.
    ```swift
    let queryItems: QueryItems = [
        "param1": "value1",
        "param2": "value2"
    ]
    ```
- POST
    - `QueryItems`는 body를 구성하는데 사용이 됩니다.
    - JSON형식으로 body에 포함되어 데이터를 보낼 수 있는 구조입니다.

## 2. Request 전달 + 3. 서버에서 받은 데이터 Decoding
- 이제 Request를 서버에 전달하고 서버로 받은 데이터를 디코딩하느 과정을 한번에 구현해보겠습니다. (~async/await으로 구현하니까 분리할 필요가 없어요;;~)

### 2-1. `Network` 프로토콜 정의
- Network 프로토콜에는 네트워크 요청을 처리하는 send함수를 정의해줬습니다. request를 보내야하니 다양한 Request타입을 처리하기 위해서 제네릭으로 선언했습니다.
```swift
protocol Network {
    func send<T: Request>(_ request: T) async throws -> T.Response
}
```

### 2-2. NetworkImp 클래스 구현
-  Network 프로토콜 구현체를 만들어 줬습니다.
```swift
final class NetworkImp: Network {
    
    private let session: URLSession
    
    // 의존성 주입을 통해 테스트 가능한 환경을 구축하였습니다.
    init(session: URLSession) {
        self.session = session
    }
    
    func send<T>(_ request: T) async throws -> T.Response where T: Request {
        do {
            // RequestFactory를 사용하여 URLRequest 생성
            let urlRequest = try RequestFactory(request: request).urlRequestRepresentation()
            
            // URLSession을 사용하여 데이터 요청
            let (data, response) = try await session.data(for: urlRequest)
            
            // 응답 검증
            try validate(response)
            
            // 데이터 디코딩
            return try JSONDecoder().decode(T.Response.self, from: data)
        } catch let error {
            // 에러 맵핑 및 재던지기
            throw mapToNetworkError(error)
        }
    }
}
```
### 2-3. 검증 및 에러 처리
- `validate()`는 HTTP statusCode의 따라서 `NetworkError`를 반환해주는 함수입니다.
- `mapToNetworkError()`는 전반적인 오류를 `NetworkError`로 변환합니다.

#### 오류 처리를 왜 두번이나?
- `validate()`는 Response의 statusCode를 검증하여 오류를 처리해주지만 전반적인 오류 처리의 한계(디코딩에러, 네트워크 연결 문제 등등)점이 있다고 느껴졌습니다. 이를 보완하기 위해 `mapToNetworkError()`를 통해서 `validate()`가 처리하지 못하는 오류를 관리하도록 구현했습니다.
```swift
extension NetworkImp {
    private func validate(_ response: URLResponse) throws {
        guard let httpResponse = response as? HTTPURLResponse else {
            throw NetworkError.unknownError
        }
        
        switch httpResponse.statusCode {
        case 200..<300: return
        case 400..<500: throw NetworkError.clientError(
            code: httpResponse.statusCode,
            message: "클라이언트 에러입니다."
        )
        case 500..<600: throw NetworkError.serverError
        default: throw NetworkError.unknownError
        }
    }
    
    private func mapToNetworkError(_ error: Error) -> NetworkError {
        if let networkError = error as? NetworkError {
            return networkError
        }
        
        if let urlError = error as? URLError {
            return .invalidURL(message: urlError.localizedDescription)
        }
        
        if error is DecodingError {
            return .jsonDecodingError
        }
        
        return .unknownError
    }
}
```

## 아쉬운 점
- 네트워크 오류 처리 부분이 매끄럽지 못해 예상치 못한 오류들을 완벽히 다루지 못했는데 프로젝트를 진행하면서 보완해보겠습니다.

## 📮 Issue 번호
- resolved: #4 
