### PR TITLE
FEAT: 아이디찾기 뷰 구현

### DIFF
--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		B18F450D2D3994380030F7DB /* FindAccountMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F450C2D3994380030F7DB /* FindAccountMainView.swift */; };
 		B18F45102D3997280030F7DB /* FindAccountHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F450F2D3997280030F7DB /* FindAccountHeaderView.swift */; };
 		B18F45122D3A26520030F7DB /* FindAccountInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F45112D3A26520030F7DB /* FindAccountInputView.swift */; };
+		B18F45152D3A40BE0030F7DB /* FindAccountType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F45142D3A40BE0030F7DB /* FindAccountType.swift */; };
 		B1D9A0E72D3686BA00E84934 /* CountdownTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D9A0E62D3686BA00E84934 /* CountdownTimer.swift */; };
 		E230669A2D2126B9001B509A /* PreviewScoresData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23066992D2126B9001B509A /* PreviewScoresData.swift */; };
 		E23824E12D0C3157009E7989 /* BeginOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23824E02D0C3157009E7989 /* BeginOnboardingViewController.swift */; };
@@ -184,6 +185,7 @@
 		B18F450C2D3994380030F7DB /* FindAccountMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindAccountMainView.swift; sourceTree = "<group>"; };
 		B18F450F2D3997280030F7DB /* FindAccountHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindAccountHeaderView.swift; sourceTree = "<group>"; };
 		B18F45112D3A26520030F7DB /* FindAccountInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindAccountInputView.swift; sourceTree = "<group>"; };
+		B18F45142D3A40BE0030F7DB /* FindAccountType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindAccountType.swift; sourceTree = "<group>"; };
 		B1D9A0E62D3686BA00E84934 /* CountdownTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountdownTimer.swift; sourceTree = "<group>"; };
 		E23066992D2126B9001B509A /* PreviewScoresData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewScoresData.swift; sourceTree = "<group>"; };
 		E23824E02D0C3157009E7989 /* BeginOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeginOnboardingViewController.swift; sourceTree = "<group>"; };
@@ -393,9 +395,10 @@
 		54DB0D9E2D09514000ABD458 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				54DB0D9F2D09519D00ABD458 /* Extensions */,
 				B1D9A0E52D3686A100E84934 /* Manager */,
 				E29BF8532D117CD5006DC6D0 /* Model */,
-				54DB0D9F2D09519D00ABD458 /* Extensions */,
+				B18F45132D3A406C0030F7DB /* Types */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -549,6 +552,14 @@
 				B18F45112D3A26520030F7DB /* FindAccountInputView.swift */,
 			);
 			path = Components;
+			sourceTree = "<group>";
+		};
+		B18F45132D3A406C0030F7DB /* Types */ = {
+			isa = PBXGroup;
+			children = (
+				B18F45142D3A40BE0030F7DB /* FindAccountType.swift */,
+			);
+			path = Types;
 			sourceTree = "<group>";
 		};
 		B1D9A0E52D3686A100E84934 /* Manager */ = {
@@ -1080,6 +1091,7 @@
 				B168B76A2D2807470000F32E /* NameInputViewController.swift in Sources */,
 				548566552D124260002BAEE3 /* ExampleService.swift in Sources */,
 				E29CCD3F2D298656004AA30A /* IncorrectRankView.swift in Sources */,
+				B18F45152D3A40BE0030F7DB /* FindAccountType.swift in Sources */,
 				E239630B2D083B900092B39B /* SceneDelegate.swift in Sources */,
 				E2D70FEC2D0EBDDD005A3F51 /* CheckListCell.swift in Sources */,
 				E28BAD772D2C111100B8388D /* CustomAlertView.swift in Sources */,

--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -53,6 +53,9 @@
 		B17FE3082D27F87E002EC7D7 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17FE3072D27F87E002EC7D7 /* String+.swift */; };
 		B17FE30A2D27F8E9002EC7D7 /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17FE3092D27F8E9002EC7D7 /* UITextField+.swift */; };
 		B17FE30C2D27F931002EC7D7 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17FE30B2D27F931002EC7D7 /* CustomTextField.swift */; };
+		B18F450A2D39901D0030F7DB /* FindIdViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F45092D39901D0030F7DB /* FindIdViewController.swift */; };
+		B18F450D2D3994380030F7DB /* FindAccountMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F450C2D3994380030F7DB /* FindAccountMainView.swift */; };
+		B18F45102D3997280030F7DB /* FindAccountHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F450F2D3997280030F7DB /* FindAccountHeaderView.swift */; };
 		B1D9A0E72D3686BA00E84934 /* CountdownTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D9A0E62D3686BA00E84934 /* CountdownTimer.swift */; };
 		E230669A2D2126B9001B509A /* PreviewScoresData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23066992D2126B9001B509A /* PreviewScoresData.swift */; };
 		E23824E12D0C3157009E7989 /* BeginOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23824E02D0C3157009E7989 /* BeginOnboardingViewController.swift */; };
@@ -176,6 +179,9 @@
 		B17FE3072D27F87E002EC7D7 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		B17FE3092D27F8E9002EC7D7 /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
 		B17FE30B2D27F931002EC7D7 /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
+		B18F45092D39901D0030F7DB /* FindIdViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindIdViewController.swift; sourceTree = "<group>"; };
+		B18F450C2D3994380030F7DB /* FindAccountMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindAccountMainView.swift; sourceTree = "<group>"; };
+		B18F450F2D3997280030F7DB /* FindAccountHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindAccountHeaderView.swift; sourceTree = "<group>"; };
 		B1D9A0E62D3686BA00E84934 /* CountdownTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountdownTimer.swift; sourceTree = "<group>"; };
 		E23066992D2126B9001B509A /* PreviewScoresData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewScoresData.swift; sourceTree = "<group>"; };
 		E23824E02D0C3157009E7989 /* BeginOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeginOnboardingViewController.swift; sourceTree = "<group>"; };
@@ -359,6 +365,7 @@
 				54E91B742D18FA9600474D0A /* CommonViews */,
 				54C7A30E2D14613B001175D9 /* Login */,
 				B168B7552D2806E50000F32E /* Signup */,
+				B18F45072D398D3C0030F7DB /* FindAccount */,
 				54DB0D972D0950A500ABD458 /* Home */,
 			);
 			path = Feature;
@@ -507,6 +514,48 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		B18F45072D398D3C0030F7DB /* FindAccount */ = {
+			isa = PBXGroup;
+			children = (
+				B18F450B2D3992C10030F7DB /* View */,
+				B18F45082D398FFD0030F7DB /* ViewController */,
+			);
+			path = FindAccount;
+			sourceTree = "<group>";
+		};
+		B18F45082D398FFD0030F7DB /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				B18F45092D39901D0030F7DB /* FindIdViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
+		B18F450B2D3992C10030F7DB /* View */ = {
+			isa = PBXGroup;
+			children = (
+				B18F450E2D3996F80030F7DB /* Components */,
+				B18F450C2D3994380030F7DB /* FindAccountMainView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		B18F450E2D3996F80030F7DB /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				B18F450F2D3997280030F7DB /* FindAccountHeaderView.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		B1D9A0E52D3686A100E84934 /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				B1D9A0E62D3686BA00E84934 /* CountdownTimer.swift */,
+			);
+			path = Manager;
+			sourceTree = "<group>";
+		};
 		E23824DF2D0C1FA7009E7989 /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
@@ -521,14 +570,6 @@
 			path = Onboarding;
 			sourceTree = "<group>";
 		};
-        B1D9A0E52D3686A100E84934 /* Manager */ = {
-        isa = PBXGroup;
-        children = (
-        B1D9A0E62D3686BA00E84934 /* CountdownTimer.swift */,
-        );
-        path = Manager;
-        sourceTree = "<group>";
-        };
 		E23962FC2D083B8F0092B39B = {
 			isa = PBXGroup;
 			children = (
@@ -978,6 +1019,7 @@
 				E29CCD452D298656004AA30A /* SingleSupplementConceptView.swift in Sources */,
 				B168B76B2D2807470000F32E /* VerificationCodeViewController.swift in Sources */,
 				B16288222D2E3CAB008057D0 /* UINavigationBar+.swift in Sources */,
+				B18F450A2D39901D0030F7DB /* FindIdViewController.swift in Sources */,
 				B168B7602D28073C0000F32E /* SignupHeaderView.swift in Sources */,
 				B168B7712D28276F0000F32E /* IdInputView.swift in Sources */,
 				54C7A3102D146190001175D9 /* LoginViewController.swift in Sources */,
@@ -1021,6 +1063,7 @@
 				E29CCD2A2D29855B004AA30A /* QuestionOptionLabel.swift in Sources */,
 				E25856D42D0D766900355667 /* CheckConceptViewController.swift in Sources */,
 				E25F94C82D0CAF1B00BA765F /* BeginTestViewController.swift in Sources */,
+				B18F450D2D3994380030F7DB /* FindAccountMainView.swift in Sources */,
 				B168B7692D2807470000F32E /* EmailInputViewController.swift in Sources */,
 				54DB0D9D2D09513300ABD458 /* AppCoordinator.swift in Sources */,
 				54E91B762D18FACD00474D0A /* RoundButton.swift in Sources */,
@@ -1046,6 +1089,7 @@
 				B16288282D30EB45008057D0 /* VerificationCodeViewModel.swift in Sources */,
 				E230669A2D2126B9001B509A /* PreviewScoresData.swift in Sources */,
 				B1D9A0E72D3686BA00E84934 /* CountdownTimer.swift in Sources */,
+				B18F45102D3997280030F7DB /* FindAccountHeaderView.swift in Sources */,
 				E29BF8552D117CF1006DC6D0 /* SurveyCheckList.swift in Sources */,
 				E2DD0E862D2146D900DA3D18 /* IncorrectCountData.swift in Sources */,
 				E29CCD3E2D298656004AA30A /* ConceptBarGraphView.swift in Sources */,

--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		B18F45102D3997280030F7DB /* FindAccountHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F450F2D3997280030F7DB /* FindAccountHeaderView.swift */; };
 		B18F45122D3A26520030F7DB /* FindAccountInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F45112D3A26520030F7DB /* FindAccountInputView.swift */; };
 		B18F45152D3A40BE0030F7DB /* FindAccountType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F45142D3A40BE0030F7DB /* FindAccountType.swift */; };
+		B18F45182D3A528B0030F7DB /* FindIdViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F45172D3A528B0030F7DB /* FindIdViewModel.swift */; };
 		B1D9A0E72D3686BA00E84934 /* CountdownTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D9A0E62D3686BA00E84934 /* CountdownTimer.swift */; };
 		E230669A2D2126B9001B509A /* PreviewScoresData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23066992D2126B9001B509A /* PreviewScoresData.swift */; };
 		E23824E12D0C3157009E7989 /* BeginOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23824E02D0C3157009E7989 /* BeginOnboardingViewController.swift */; };
@@ -186,6 +187,7 @@
 		B18F450F2D3997280030F7DB /* FindAccountHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindAccountHeaderView.swift; sourceTree = "<group>"; };
 		B18F45112D3A26520030F7DB /* FindAccountInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindAccountInputView.swift; sourceTree = "<group>"; };
 		B18F45142D3A40BE0030F7DB /* FindAccountType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindAccountType.swift; sourceTree = "<group>"; };
+		B18F45172D3A528B0030F7DB /* FindIdViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindIdViewModel.swift; sourceTree = "<group>"; };
 		B1D9A0E62D3686BA00E84934 /* CountdownTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountdownTimer.swift; sourceTree = "<group>"; };
 		E23066992D2126B9001B509A /* PreviewScoresData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewScoresData.swift; sourceTree = "<group>"; };
 		E23824E02D0C3157009E7989 /* BeginOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeginOnboardingViewController.swift; sourceTree = "<group>"; };
@@ -524,6 +526,7 @@
 			children = (
 				B18F450B2D3992C10030F7DB /* View */,
 				B18F45082D398FFD0030F7DB /* ViewController */,
+				B18F45162D3A52680030F7DB /* ViewModel */,
 			);
 			path = FindAccount;
 			sourceTree = "<group>";
@@ -560,6 +563,14 @@
 				B18F45142D3A40BE0030F7DB /* FindAccountType.swift */,
 			);
 			path = Types;
+			sourceTree = "<group>";
+		};
+		B18F45162D3A52680030F7DB /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				B18F45172D3A528B0030F7DB /* FindIdViewModel.swift */,
+			);
+			path = ViewModel;
 			sourceTree = "<group>";
 		};
 		B1D9A0E52D3686A100E84934 /* Manager */ = {
@@ -1052,6 +1063,7 @@
 				E29CCD2F2D29855B004AA30A /* TestTimeLabel.swift in Sources */,
 				B168B7732D2846C80000F32E /* PasswordInputViewController.swift in Sources */,
 				E239630D2D083B900092B39B /* ViewController.swift in Sources */,
+				B18F45182D3A528B0030F7DB /* FindIdViewModel.swift in Sources */,
 				B16288262D300CBA008057D0 /* PasswordInputViewModel.swift in Sources */,
 				E23824E12D0C3157009E7989 /* BeginOnboardingViewController.swift in Sources */,
 				E29CCD292D29855B004AA30A /* QuestionNumberLabel.swift in Sources */,

--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		B18F450A2D39901D0030F7DB /* FindIdViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F45092D39901D0030F7DB /* FindIdViewController.swift */; };
 		B18F450D2D3994380030F7DB /* FindAccountMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F450C2D3994380030F7DB /* FindAccountMainView.swift */; };
 		B18F45102D3997280030F7DB /* FindAccountHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F450F2D3997280030F7DB /* FindAccountHeaderView.swift */; };
+		B18F45122D3A26520030F7DB /* FindAccountInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F45112D3A26520030F7DB /* FindAccountInputView.swift */; };
 		B1D9A0E72D3686BA00E84934 /* CountdownTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D9A0E62D3686BA00E84934 /* CountdownTimer.swift */; };
 		E230669A2D2126B9001B509A /* PreviewScoresData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23066992D2126B9001B509A /* PreviewScoresData.swift */; };
 		E23824E12D0C3157009E7989 /* BeginOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23824E02D0C3157009E7989 /* BeginOnboardingViewController.swift */; };
@@ -182,6 +183,7 @@
 		B18F45092D39901D0030F7DB /* FindIdViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindIdViewController.swift; sourceTree = "<group>"; };
 		B18F450C2D3994380030F7DB /* FindAccountMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindAccountMainView.swift; sourceTree = "<group>"; };
 		B18F450F2D3997280030F7DB /* FindAccountHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindAccountHeaderView.swift; sourceTree = "<group>"; };
+		B18F45112D3A26520030F7DB /* FindAccountInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindAccountInputView.swift; sourceTree = "<group>"; };
 		B1D9A0E62D3686BA00E84934 /* CountdownTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountdownTimer.swift; sourceTree = "<group>"; };
 		E23066992D2126B9001B509A /* PreviewScoresData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewScoresData.swift; sourceTree = "<group>"; };
 		E23824E02D0C3157009E7989 /* BeginOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeginOnboardingViewController.swift; sourceTree = "<group>"; };
@@ -544,6 +546,7 @@
 			isa = PBXGroup;
 			children = (
 				B18F450F2D3997280030F7DB /* FindAccountHeaderView.swift */,
+				B18F45112D3A26520030F7DB /* FindAccountInputView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1045,6 +1048,7 @@
 				E29CCD2C2D29855B004AA30A /* TestButton.swift in Sources */,
 				B168B75F2D28073C0000F32E /* SignupFooterView.swift in Sources */,
 				B162881C2D2CFC63008057D0 /* UIView+.swift in Sources */,
+				B18F45122D3A26520030F7DB /* FindAccountInputView.swift in Sources */,
 				541878542D0E21620089F478 /* HTTPMethod.swift in Sources */,
 				548566502D1241A4002BAEE3 /* ExampleRequest.swift in Sources */,
 				E29CCD422D298656004AA30A /* PreviewResultViewModel.swift in Sources */,

--- a/QRIZ/Feature/CommonViews/CustomAlert/CustomAlertView.swift
+++ b/QRIZ/Feature/CommonViews/CustomAlert/CustomAlertView.swift
@@ -17,6 +17,7 @@ final class CustomAlertView: UIView {
         label.numberOfLines = 1
         return label
     }()
+    
     private let descriptionLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 14)
@@ -25,10 +26,41 @@ final class CustomAlertView: UIView {
         label.numberOfLines = 2
         return label
     }()
-    private lazy var confirmButton: UIButton = UIButton(frame: .zero)
-    private lazy var cancelButton: UIButton = UIButton(frame: .zero)
     
-    init(alertType: AlertType, title: String, titleLine: Int = 1, description: String, descriptionLine: Int) {
+    private lazy var confirmButton: UIButton = {
+        return createButton(
+            title: "확인",
+            font: UIFont.systemFont(ofSize: 14, weight: .medium),
+            titleColor: .white,
+            backgroundColor: .customBlue500
+        )
+    }()
+    
+    private lazy var cancelButton: UIButton = {
+        return createButton(
+            title: "취소",
+            font: UIFont.systemFont(ofSize: 16, weight: .bold),
+            titleColor: .customBlue500,
+            backgroundColor: .clear,
+            borderColor: .customBlue500
+        )
+    }()
+    
+    private lazy var buttonHStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [cancelButton, confirmButton])
+        stackView.axis = .horizontal
+        stackView.distribution = .fillEqually
+        stackView.spacing = 8
+        return stackView
+    }()
+    
+    init(
+        alertType: AlertType,
+        title: String,
+        titleLine: Int = 1,
+        description: String,
+        descriptionLine: Int
+    ) {
         super.init(frame: .zero)
         backgroundColor = .coolNeutral100
         layer.cornerRadius = 8
@@ -43,7 +75,6 @@ final class CustomAlertView: UIView {
     }
     
     func setButtonAction(_ isConfirmButton: Bool, action: UIAction) {
-
         if isConfirmButton {
             confirmButton.addAction(action, for: .touchUpInside)
         } else {
@@ -61,30 +92,26 @@ final class CustomAlertView: UIView {
         }
     }
     
-    private func createButton(isConfirmButton: Bool) -> UIButton {
-        let button = UIButton()
+    private func createButton(
+        title: String,
+        font: UIFont,
+        titleColor: UIColor,
+        backgroundColor: UIColor,
+        borderColor: UIColor = .clear
+    ) -> UIButton {
+        let button = UIButton(frame: .zero)
         button.layer.cornerRadius = 8
-        var titleStr: NSAttributedString
-        
-        switch isConfirmButton {
-            
-        case true:
-            titleStr = NSAttributedString(string: "확인", attributes: [
-                .font: UIFont.systemFont(ofSize: 14, weight: .medium), .foregroundColor: UIColor.white
-            ])
-            button.backgroundColor = .customBlue500
-            
-        case false:
-            titleStr = NSAttributedString(string: "취소", attributes: [
-                .font: UIFont.systemFont(ofSize: 16, weight: .bold), .foregroundColor: UIColor.customBlue500
-            ])
-            button.layer.borderColor = UIColor.customBlue500.cgColor
-            button.layer.borderWidth = 1
-            button.backgroundColor = .clear
-        }
-        
+        let titleStr = NSAttributedString(
+            string: title,
+            attributes: [
+                .font: font,
+                .foregroundColor: titleColor
+            ]
+        )
         button.setAttributedTitle(titleStr, for: .normal)
-        
+        button.backgroundColor = backgroundColor
+        button.layer.borderWidth = 1
+        button.layer.borderColor = borderColor.cgColor
         return button
     }
     
@@ -100,44 +127,40 @@ final class CustomAlertView: UIView {
             titleLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20),
             titleLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20),
             titleLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: 20),
-            titleLabel.heightAnchor.constraint(equalToConstant: 24),
             descriptionLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
             descriptionLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
-            descriptionLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 4),
-            descriptionLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: CGFloat(22 * descriptionLabel.numberOfLines))
         ])
     }
     
     private func addButtons(alertType: AlertType) {
+        addSubview(buttonHStackView)
         
-        confirmButton = createButton(isConfirmButton: true)
-        
-        addSubview(confirmButton)
-        confirmButton.translatesAutoresizingMaskIntoConstraints = false
-
-        NSLayoutConstraint.activate([
-            confirmButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -20),
-            confirmButton.heightAnchor.constraint(equalToConstant: 40)
-        ])
+        let isCancelButtonHidden: Bool
+        let buttonStackHeight: CGFloat
+        let descriptionTopSpacing: CGFloat
         
         switch alertType {
-        case .canCancel:
-            cancelButton = createButton(isConfirmButton: false)
-            addSubview(cancelButton)
-            cancelButton.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                confirmButton.widthAnchor.constraint(equalToConstant: 123.5),
-                confirmButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20),
-                cancelButton.bottomAnchor.constraint(equalTo: confirmButton.bottomAnchor),
-                cancelButton.heightAnchor.constraint(equalTo: confirmButton.heightAnchor),
-                cancelButton.widthAnchor.constraint(equalTo: confirmButton.widthAnchor),
-                cancelButton.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20)
-            ])
         case .onlyConfirm:
-            NSLayoutConstraint.activate([
-                confirmButton.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20),
-                confirmButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20)
-            ])
+            isCancelButtonHidden = true
+            buttonStackHeight = 48
+            descriptionTopSpacing = 8
+        case .canCancel:
+            isCancelButtonHidden = false
+            buttonStackHeight = 40
+            descriptionTopSpacing = 4
         }
+        
+        cancelButton.isHidden = isCancelButtonHidden
+        buttonHStackView.heightAnchor.constraint(equalToConstant: buttonStackHeight).isActive = true
+        descriptionLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: descriptionTopSpacing).isActive = true
+        
+        buttonHStackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            buttonHStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20),
+            buttonHStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20),
+            buttonHStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -20),
+            buttonHStackView.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor, constant: 16),
+        ])
     }
 }

--- a/QRIZ/Feature/CommonViews/CustomAlert/CustomAlertViewController.swift
+++ b/QRIZ/Feature/CommonViews/CustomAlert/CustomAlertViewController.swift
@@ -6,15 +6,32 @@
 //
 
 import UIKit
+import Combine
 
 final class CustomAlertViewController: UIViewController {
     
-    private var alertView: CustomAlertView = CustomAlertView(alertType: .onlyConfirm, title: "", description: "", descriptionLine: 0)
+    private let alertView: CustomAlertView
     
-    init() {
+    init(
+        alertType: AlertType,
+        title: String,
+        titleLine: Int = 1,
+        description: String,
+        descriptionLine: Int = 2,
+        confirmAction: UIAction? = nil,
+        cancelAction: UIAction? = nil
+    ) {
+        self.alertView = CustomAlertView(
+            alertType: alertType,
+            title: title,
+            titleLine: titleLine,
+            description: description,
+            descriptionLine: descriptionLine
+        )
         super.init(nibName: nil, bundle: nil)
         self.modalPresentationStyle = .overFullScreen
         self.modalTransitionStyle = .crossDissolve
+        setupButtonActions(confirmAction: confirmAction, cancelAction: cancelAction)
     }
     
     required init?(coder: NSCoder) {
@@ -27,8 +44,15 @@ final class CustomAlertViewController: UIViewController {
         addViews()
     }
     
-    func setAlertView(alertView: CustomAlertView) {
-        self.alertView = alertView
+    func setupButtonActions(confirmAction: UIAction?, cancelAction: UIAction?) {
+        
+        if let confirmAction = confirmAction {
+            alertView.setButtonAction(true, action: confirmAction)
+        }
+        
+        if let cancelAction = cancelAction {
+            alertView.setButtonAction(false, action: cancelAction)
+        }
     }
     
     private func addViews() {
@@ -40,8 +64,8 @@ final class CustomAlertViewController: UIViewController {
         NSLayoutConstraint.activate([
             alertView.centerXAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.centerXAnchor),
             alertView.centerYAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.centerYAnchor),
-            alertView.widthAnchor.constraint(equalToConstant: 295),
-            alertView.heightAnchor.constraint(equalToConstant: 146)
+            alertView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 40),
+            alertView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -40),
         ])
     }
 }

--- a/QRIZ/Feature/FindAccount/View/Components/FindAccountHeaderView.swift
+++ b/QRIZ/Feature/FindAccount/View/Components/FindAccountHeaderView.swift
@@ -1,0 +1,85 @@
+//
+//  FindAccountHeaderView.swift
+//  QRIZ
+//
+//  Created by 김세훈 on 1/17/25.
+//
+
+import UIKit
+
+final class FindAccountHeaderView: UIView {
+    
+    // MARK: - Enums
+    
+    private enum Metric {
+        static let descriptionLabelTopOffset: CGFloat = 10.0
+    }
+    
+    // MARK: - UI
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 22, weight: .bold)
+        label.textColor = .coolNeutral800
+        return label
+    }()
+    
+    private let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16, weight: .regular)
+        label.textColor = .coolNeutral500
+        label.numberOfLines = 2
+        return label
+    }()
+    
+    // MARK: - initialize
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        addSubviews()
+        setupConstraints()
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Functions
+    
+    private func setupUI() {
+        self.backgroundColor = .white
+    }
+    
+    func configure(title: String, description: String) {
+        titleLabel.text = title
+        descriptionLabel.text = description
+    }
+}
+
+// MARK: - Layout Setup
+
+extension FindAccountHeaderView {
+    private func addSubviews() {
+        [
+            titleLabel,
+            descriptionLabel
+        ].forEach(addSubview(_:))
+    }
+    
+    private func setupConstraints() {
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: topAnchor),
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            
+            descriptionLabel.topAnchor.constraint(
+                equalTo: titleLabel.bottomAnchor, constant: Metric.descriptionLabelTopOffset
+            ),
+            descriptionLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            descriptionLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+}

--- a/QRIZ/Feature/FindAccount/View/Components/FindAccountInputView.swift
+++ b/QRIZ/Feature/FindAccount/View/Components/FindAccountInputView.swift
@@ -17,6 +17,14 @@ final class FindAccountInputView: UIView {
         static let inputErrorLabelTopOffset: CGFloat = 8.0
     }
     
+    // MARK: - Enums
+    
+    private enum Attributes {
+        static let titleLabelText: String = "이메일"
+        static let placeholder: String = "chaeyoung1106@qriz.com"
+        static let errorLabelText: String = "이메일을 다시 확인해 주세요."
+    }
+    
     // MARK: - Properties
     
     
@@ -24,19 +32,21 @@ final class FindAccountInputView: UIView {
     
     private let titleLabel: UILabel = {
         let label = UILabel()
+        label.text = Attributes.titleLabelText
         label.font = .systemFont(ofSize: 16, weight: .bold)
         label.textColor = .coolNeutral600
         return label
     }()
     
     private lazy var textField: UITextField = {
-        let textField = CustomTextField(placeholder: "")
+        let textField = CustomTextField(placeholder: Attributes.placeholder)
         textField.delegate = self
         return textField
     }()
     
     private let inputErrorLabel: UILabel = {
         let label = UILabel()
+        label.text = Attributes.errorLabelText
         label.font = .systemFont(ofSize: 14, weight: .regular)
         label.textColor = .customRed500
         label.isHidden = true
@@ -60,18 +70,6 @@ final class FindAccountInputView: UIView {
     
     private func setupUI() {
         self.backgroundColor = .white
-    }
-    
-    func configure(titleText: String, placeholder: String, errorText: String) {
-        textField.attributedPlaceholder = NSAttributedString(
-            string: placeholder,
-            attributes: [
-                .foregroundColor: UIColor.coolNeutral300,
-                .font: UIFont.systemFont(ofSize: 14, weight: .medium)
-            ]
-        )
-        titleLabel.text = titleText
-        inputErrorLabel.text = errorText
     }
     
     func updateErrorState(isValid: Bool) {

--- a/QRIZ/Feature/FindAccount/View/Components/FindAccountInputView.swift
+++ b/QRIZ/Feature/FindAccount/View/Components/FindAccountInputView.swift
@@ -1,0 +1,127 @@
+//
+//  FindAccountInputView.swift
+//  QRIZ
+//
+//  Created by 김세훈 on 1/17/25.
+//
+
+import UIKit
+
+final class FindAccountInputView: UIView {
+    
+    // MARK: - Enums
+    
+    private enum Metric {
+        static let textFieldHeight: CGFloat = 48.0
+        static let textFieldTopOffset: CGFloat = 12.0
+        static let inputErrorLabelTopOffset: CGFloat = 8.0
+    }
+    
+    // MARK: - Properties
+    
+    
+    // MARK: - UI
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16, weight: .bold)
+        label.textColor = .coolNeutral600
+        return label
+    }()
+    
+    private lazy var textField: UITextField = {
+        let textField = CustomTextField(placeholder: "")
+        textField.delegate = self
+        return textField
+    }()
+    
+    private let inputErrorLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 14, weight: .regular)
+        label.textColor = .customRed500
+        label.isHidden = true
+        return label
+    }()
+    
+    // MARK: - initialize
+    
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        addSubviews()
+        setupConstraints()
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Functions
+    
+    private func setupUI() {
+        self.backgroundColor = .white
+    }
+    
+    func configure(titleText: String, placeholder: String, errorText: String) {
+        textField.attributedPlaceholder = NSAttributedString(
+            string: placeholder,
+            attributes: [
+                .foregroundColor: UIColor.coolNeutral300,
+                .font: UIFont.systemFont(ofSize: 14, weight: .medium)
+            ]
+        )
+        titleLabel.text = titleText
+        inputErrorLabel.text = errorText
+    }
+    
+    func updateErrorState(isValid: Bool) {
+        inputErrorLabel.isHidden = isValid
+        textField.layer.borderColor = isValid
+        ? UIColor.clear.cgColor
+        : UIColor.customRed500.cgColor
+    }
+}
+
+// MARK: - Layout Setup
+
+extension FindAccountInputView {
+    private func addSubviews() {
+        [
+            titleLabel,
+            textField,
+            inputErrorLabel
+        ].forEach(addSubview(_:))
+    }
+    
+    private func setupConstraints() {
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        inputErrorLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: topAnchor),
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            
+            textField.topAnchor.constraint(
+                equalTo: titleLabel.bottomAnchor, constant: Metric.textFieldTopOffset
+            ),
+            textField.leadingAnchor.constraint(equalTo: leadingAnchor),
+            textField.trailingAnchor.constraint(equalTo: trailingAnchor),
+            textField.heightAnchor.constraint(equalToConstant: Metric.textFieldHeight),
+            
+            inputErrorLabel.topAnchor.constraint(equalTo: textField.bottomAnchor, constant: Metric.inputErrorLabelTopOffset),
+            inputErrorLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            inputErrorLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
+            inputErrorLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+}
+
+// MARK: - UITextFieldDelegate
+
+extension FindAccountInputView: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+}

--- a/QRIZ/Feature/FindAccount/View/Components/FindAccountInputView.swift
+++ b/QRIZ/Feature/FindAccount/View/Components/FindAccountInputView.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 
 final class FindAccountInputView: UIView {
     
@@ -27,6 +28,9 @@ final class FindAccountInputView: UIView {
     
     // MARK: - Properties
     
+    var textChangedPublisher: AnyPublisher<String, Never> {
+        textField.textPublisher
+    }
     
     // MARK: - UI
     

--- a/QRIZ/Feature/FindAccount/View/FindAccountMainView.swift
+++ b/QRIZ/Feature/FindAccount/View/FindAccountMainView.swift
@@ -13,23 +13,31 @@ final class FindAccountMainView: UIView {
     
     private enum Metric {
         static let headerViewTopOffset: CGFloat = 24.0
+        static let inputViewTopOffset: CGFloat = 32.0
         static let horizontalMargin: CGFloat = 18.0
     }
     
     // MARK: - Properties
     
     private let findAccountHeaderView = FindAccountHeaderView()
+    private let findAccountInputView = FindAccountInputView()
     
     // MARK: - Initialize
     
     init(
         title: String,
-        description: String
+        description: String,
+        inputTitle: String,
+        placeholder: String,
+        errorText: String
     ) {
         super.init(frame: .zero)
         setupUI(
-            title: title,
-            description: description
+            headerTitle: title,
+            description: description,
+            inputTitle: inputTitle,
+            placeholder: placeholder,
+            errorText: errorText
         )
         addSubviews()
         setupConstraints()
@@ -42,11 +50,19 @@ final class FindAccountMainView: UIView {
     // MARK: - Functions
     
     private func setupUI(
-        title: String,
-        description: String
+        headerTitle: String,
+        description: String,
+        inputTitle: String,
+        placeholder: String,
+        errorText: String
     ) {
         self.backgroundColor = .white
-        findAccountHeaderView.configure(title: title, description: description)
+        findAccountHeaderView.configure(title: headerTitle, description: description)
+        findAccountInputView.configure(
+            titleText: inputTitle,
+            placeholder: placeholder,
+            errorText: errorText
+        )
     }
 }
 
@@ -56,12 +72,14 @@ extension FindAccountMainView {
     private func addSubviews() {
         [
             findAccountHeaderView,
+            findAccountInputView
         ].forEach(addSubview(_:))
     }
     
     private func setupConstraints() {
         findAccountHeaderView.translatesAutoresizingMaskIntoConstraints = false
-
+        findAccountInputView.translatesAutoresizingMaskIntoConstraints = false
+        
         NSLayoutConstraint.activate([
             findAccountHeaderView.topAnchor.constraint(
                 equalTo: safeAreaLayoutGuide.topAnchor,
@@ -73,7 +91,20 @@ extension FindAccountMainView {
             ),
             findAccountHeaderView.trailingAnchor.constraint(
                 equalTo: trailingAnchor,
+                constant: -Metric.horizontalMargin
+            ),
+            
+            findAccountInputView.topAnchor.constraint(
+                equalTo: findAccountHeaderView.bottomAnchor,
+                constant: Metric.inputViewTopOffset
+            ),
+            findAccountInputView.leadingAnchor.constraint(
+                equalTo: leadingAnchor,
                 constant: Metric.horizontalMargin
+            ),
+            findAccountInputView.trailingAnchor.constraint(
+                equalTo: trailingAnchor,
+                constant: -Metric.horizontalMargin
             ),
         ])
     }

--- a/QRIZ/Feature/FindAccount/View/FindAccountMainView.swift
+++ b/QRIZ/Feature/FindAccount/View/FindAccountMainView.swift
@@ -1,0 +1,81 @@
+//
+//  FindAccountMainView.swift
+//  QRIZ
+//
+//  Created by 김세훈 on 1/17/25.
+//
+
+import UIKit
+
+final class FindAccountMainView: UIView {
+    
+    // MARK: - Enums
+    
+    private enum Metric {
+        static let headerViewTopOffset: CGFloat = 24.0
+        static let horizontalMargin: CGFloat = 18.0
+    }
+    
+    // MARK: - Properties
+    
+    private let findAccountHeaderView = FindAccountHeaderView()
+    
+    // MARK: - Initialize
+    
+    init(
+        title: String,
+        description: String
+    ) {
+        super.init(frame: .zero)
+        setupUI(
+            title: title,
+            description: description
+        )
+        addSubviews()
+        setupConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Functions
+    
+    private func setupUI(
+        title: String,
+        description: String
+    ) {
+        self.backgroundColor = .white
+        findAccountHeaderView.configure(title: title, description: description)
+    }
+}
+
+// MARK: - Layout Setup
+
+extension FindAccountMainView {
+    private func addSubviews() {
+        [
+            findAccountHeaderView,
+        ].forEach(addSubview(_:))
+    }
+    
+    private func setupConstraints() {
+        findAccountHeaderView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            findAccountHeaderView.topAnchor.constraint(
+                equalTo: safeAreaLayoutGuide.topAnchor,
+                constant: Metric.headerViewTopOffset
+            ),
+            findAccountHeaderView.leadingAnchor.constraint(
+                equalTo: leadingAnchor,
+                constant: Metric.horizontalMargin
+            ),
+            findAccountHeaderView.trailingAnchor.constraint(
+                equalTo: trailingAnchor,
+                constant: Metric.horizontalMargin
+            ),
+        ])
+    }
+}
+

--- a/QRIZ/Feature/FindAccount/View/FindAccountMainView.swift
+++ b/QRIZ/Feature/FindAccount/View/FindAccountMainView.swift
@@ -15,12 +15,14 @@ final class FindAccountMainView: UIView {
         static let headerViewTopOffset: CGFloat = 24.0
         static let inputViewTopOffset: CGFloat = 32.0
         static let horizontalMargin: CGFloat = 18.0
+        static let signupFooterViewBottomOffset: CGFloat = -16.0
     }
     
     // MARK: - Properties
     
     private let findAccountHeaderView = FindAccountHeaderView()
-    private let findAccountInputView = FindAccountInputView()
+    let findAccountInputView = FindAccountInputView()
+    let signupFooterView = SignupFooterView()
     
     // MARK: - Initialize
     
@@ -29,7 +31,8 @@ final class FindAccountMainView: UIView {
         description: String,
         inputTitle: String,
         placeholder: String,
-        errorText: String
+        errorText: String,
+        buttonTitle: String
     ) {
         super.init(frame: .zero)
         setupUI(
@@ -37,7 +40,8 @@ final class FindAccountMainView: UIView {
             description: description,
             inputTitle: inputTitle,
             placeholder: placeholder,
-            errorText: errorText
+            errorText: errorText,
+            buttonTitle: buttonTitle
         )
         addSubviews()
         setupConstraints()
@@ -54,7 +58,8 @@ final class FindAccountMainView: UIView {
         description: String,
         inputTitle: String,
         placeholder: String,
-        errorText: String
+        errorText: String,
+        buttonTitle: String
     ) {
         self.backgroundColor = .white
         findAccountHeaderView.configure(title: headerTitle, description: description)
@@ -63,6 +68,7 @@ final class FindAccountMainView: UIView {
             placeholder: placeholder,
             errorText: errorText
         )
+        signupFooterView.configure(buttonTitle: buttonTitle)
     }
 }
 
@@ -72,13 +78,15 @@ extension FindAccountMainView {
     private func addSubviews() {
         [
             findAccountHeaderView,
-            findAccountInputView
+            findAccountInputView,
+            signupFooterView
         ].forEach(addSubview(_:))
     }
     
     private func setupConstraints() {
         findAccountHeaderView.translatesAutoresizingMaskIntoConstraints = false
         findAccountInputView.translatesAutoresizingMaskIntoConstraints = false
+        signupFooterView.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
             findAccountHeaderView.topAnchor.constraint(
@@ -106,6 +114,19 @@ extension FindAccountMainView {
                 equalTo: trailingAnchor,
                 constant: -Metric.horizontalMargin
             ),
+            
+            signupFooterView.leadingAnchor.constraint(
+                equalTo: leadingAnchor,
+                constant: Metric.horizontalMargin
+            ),
+            signupFooterView.trailingAnchor.constraint(
+                equalTo: trailingAnchor,
+                constant: -Metric.horizontalMargin
+            ),
+            signupFooterView.bottomAnchor.constraint(
+                equalTo: safeAreaLayoutGuide.bottomAnchor,
+                constant: Metric.signupFooterViewBottomOffset
+            )
         ])
     }
 }

--- a/QRIZ/Feature/FindAccount/View/FindAccountMainView.swift
+++ b/QRIZ/Feature/FindAccount/View/FindAccountMainView.swift
@@ -18,6 +18,10 @@ final class FindAccountMainView: UIView {
         static let signupFooterViewBottomOffset: CGFloat = -16.0
     }
     
+    private enum Attributes {
+        static let buttonTitle: String = "이메일 발송"
+    }
+    
     // MARK: - Properties
     
     private let findAccountHeaderView = FindAccountHeaderView()
@@ -26,23 +30,9 @@ final class FindAccountMainView: UIView {
     
     // MARK: - Initialize
     
-    init(
-        title: String,
-        description: String,
-        inputTitle: String,
-        placeholder: String,
-        errorText: String,
-        buttonTitle: String
-    ) {
+    init(type: FindAccountType) {
         super.init(frame: .zero)
-        setupUI(
-            headerTitle: title,
-            description: description,
-            inputTitle: inputTitle,
-            placeholder: placeholder,
-            errorText: errorText,
-            buttonTitle: buttonTitle
-        )
+        setupUI(with: type)
         addSubviews()
         setupConstraints()
     }
@@ -53,22 +43,13 @@ final class FindAccountMainView: UIView {
     
     // MARK: - Functions
     
-    private func setupUI(
-        headerTitle: String,
-        description: String,
-        inputTitle: String,
-        placeholder: String,
-        errorText: String,
-        buttonTitle: String
-    ) {
+    private func setupUI(with type: FindAccountType) {
         self.backgroundColor = .white
-        findAccountHeaderView.configure(title: headerTitle, description: description)
-        findAccountInputView.configure(
-            titleText: inputTitle,
-            placeholder: placeholder,
-            errorText: errorText
+        findAccountHeaderView.configure(
+            title: type.headerTitle,
+            description: type.headerDescription
         )
-        signupFooterView.configure(buttonTitle: buttonTitle)
+        signupFooterView.configure(buttonTitle: Attributes.buttonTitle)
     }
 }
 

--- a/QRIZ/Feature/FindAccount/ViewController/FindIdViewController.swift
+++ b/QRIZ/Feature/FindAccount/ViewController/FindIdViewController.swift
@@ -14,12 +14,6 @@ final class FindIdViewController: UIViewController {
     
     private enum Attributes {
         static let navigationTitle: String = "아이디 찾기"
-        static let headerTitle: String = "아이디를 잊으셨나요?"
-        static let headerDescription: String = "Qriz에 가입했던 이메일을 입력하시면\n아이디를 메일로 보내드립니다."
-        static let inputTitle: String = "이메일"
-        static let placeholder: String = "chaeyoung1106@qriz.com"
-        static let errorText: String = "이메일을 다시 확인해 주세요."
-        static let buttonTitle: String = "이메일 발송"
     }
     
     // MARK: - Properties
@@ -31,14 +25,7 @@ final class FindIdViewController: UIViewController {
     // MARK: - initialize
     
     init() {
-        self.rootView = FindAccountMainView(
-            title: Attributes.headerTitle,
-            description: Attributes.headerDescription,
-            inputTitle: Attributes.inputTitle,
-            placeholder: Attributes.placeholder,
-            errorText: Attributes.errorText,
-            buttonTitle: Attributes.buttonTitle
-        )
+        self.rootView = FindAccountMainView(type: .findId)
         super.init(nibName: nil, bundle: nil)
     }
     

--- a/QRIZ/Feature/FindAccount/ViewController/FindIdViewController.swift
+++ b/QRIZ/Feature/FindAccount/ViewController/FindIdViewController.swift
@@ -79,16 +79,7 @@ final class FindIdViewController: UIViewController {
                     
                 case .navigateToAlerView:
                     // MARK: - 코디네이터 적용 필요
-                    let alert = CustomAlertViewController()
-                    alert.setAlertView(
-                        alertView: CustomAlertView(
-                            alertType: .onlyConfirm,
-                            title: "이메일 발송 완료!",
-                            description: "입력해주신 이메일 주소로아이디가\n발송되었습니다. 메일함을 확인해주세요.",
-                            descriptionLine: 3
-                        )
-                    )
-                    self.present(alert, animated: true)
+                    self.showEmailSentAlert()
                 }
             }
             .store(in: &cancellables)
@@ -102,5 +93,23 @@ final class FindIdViewController: UIViewController {
                 self?.view.endEditing(true)
             }
             .store(in: &cancellables)
+    }
+    
+    private func showEmailSentAlert() {
+        let confirmAction = UIAction { [weak self] _ in
+            guard let self = self else { return }
+            print("확인 버튼 클릭")
+            self.dismiss(animated: true)
+        }
+        
+        let alertVC = CustomAlertViewController(
+            alertType: .onlyConfirm,
+            title: "이메일 발송 완료!",
+            description: "입력해주신 이메일 주소로 아이디가\n발송되었습니다. 메일함을 확인해주세요.",
+            descriptionLine: 2,
+            confirmAction: confirmAction
+        )
+        
+        self.present(alertVC, animated: true)
     }
 }

--- a/QRIZ/Feature/FindAccount/ViewController/FindIdViewController.swift
+++ b/QRIZ/Feature/FindAccount/ViewController/FindIdViewController.swift
@@ -39,14 +39,29 @@ final class FindIdViewController: UIViewController {
         super.viewDidLoad()
         setNavigationBarTitle(title: Attributes.navigationTitle)
         bind()
+        observe()
     }
     
     override func loadView() {
         self.view = rootView
     }
     
+    deinit {
+        keyboardCancellable?.cancel()
+    }
+    
     // MARK: - Functions
     
     private func bind() {
+    }
+    
+    private func observe() {
+        keyboardCancellable = observeKeyboardNotifications(for: rootView.signupFooterView)
+        
+        view.tapGestureEndedPublisher()
+            .sink { [weak self] _ in
+                self?.view.endEditing(true)
+            }
+            .store(in: &cancellables)
     }
 }

--- a/QRIZ/Feature/FindAccount/ViewController/FindIdViewController.swift
+++ b/QRIZ/Feature/FindAccount/ViewController/FindIdViewController.swift
@@ -100,6 +100,7 @@ final class FindIdViewController: UIViewController {
             guard let self = self else { return }
             print("확인 버튼 클릭")
             self.dismiss(animated: true)
+            self.navigationController?.popToRootViewController(animated: true)
         }
         
         let alertVC = CustomAlertViewController(

--- a/QRIZ/Feature/FindAccount/ViewController/FindIdViewController.swift
+++ b/QRIZ/Feature/FindAccount/ViewController/FindIdViewController.swift
@@ -19,6 +19,7 @@ final class FindIdViewController: UIViewController {
         static let inputTitle: String = "이메일"
         static let placeholder: String = "chaeyoung1106@qriz.com"
         static let errorText: String = "이메일을 다시 확인해 주세요."
+        static let buttonTitle: String = "이메일 발송"
     }
     
     // MARK: - Properties
@@ -35,7 +36,8 @@ final class FindIdViewController: UIViewController {
             description: Attributes.headerDescription,
             inputTitle: Attributes.inputTitle,
             placeholder: Attributes.placeholder,
-            errorText: Attributes.errorText
+            errorText: Attributes.errorText,
+            buttonTitle: Attributes.buttonTitle
         )
         super.init(nibName: nil, bundle: nil)
     }

--- a/QRIZ/Feature/FindAccount/ViewController/FindIdViewController.swift
+++ b/QRIZ/Feature/FindAccount/ViewController/FindIdViewController.swift
@@ -1,0 +1,57 @@
+//
+//  FindIdViewController.swift
+//  QRIZ
+//
+//  Created by 김세훈 on 1/17/25.
+//
+
+import UIKit
+import Combine
+
+final class FindIdViewController: UIViewController {
+    
+    // MARK: - Enums
+    
+    private enum Attributes {
+        static let navigationTitle: String = "아이디 찾기"
+        static let headerTitle: String = "아이디를 잊으셨나요?"
+        static let headerDescription: String = "Qriz에 가입했던 이메일을 입력하시면\n아이디를 메일로 보내드립니다."
+    }
+    
+    // MARK: - Properties
+    
+    private let rootView: FindAccountMainView
+    private var cancellables = Set<AnyCancellable>()
+    private var keyboardCancellable: AnyCancellable?
+    
+    // MARK: - initialize
+    
+    init() {
+        self.rootView = FindAccountMainView(
+            title: Attributes.headerTitle,
+            description: Attributes.headerDescription
+        )
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setNavigationBarTitle(title: Attributes.navigationTitle)
+        bind()
+    }
+    
+    override func loadView() {
+        self.view = rootView
+    }
+    
+    // MARK: - Functions
+    
+    private func bind() {
+    }
+}

--- a/QRIZ/Feature/FindAccount/ViewController/FindIdViewController.swift
+++ b/QRIZ/Feature/FindAccount/ViewController/FindIdViewController.swift
@@ -16,6 +16,9 @@ final class FindIdViewController: UIViewController {
         static let navigationTitle: String = "아이디 찾기"
         static let headerTitle: String = "아이디를 잊으셨나요?"
         static let headerDescription: String = "Qriz에 가입했던 이메일을 입력하시면\n아이디를 메일로 보내드립니다."
+        static let inputTitle: String = "이메일"
+        static let placeholder: String = "chaeyoung1106@qriz.com"
+        static let errorText: String = "이메일을 다시 확인해 주세요."
     }
     
     // MARK: - Properties
@@ -29,7 +32,10 @@ final class FindIdViewController: UIViewController {
     init() {
         self.rootView = FindAccountMainView(
             title: Attributes.headerTitle,
-            description: Attributes.headerDescription
+            description: Attributes.headerDescription,
+            inputTitle: Attributes.inputTitle,
+            placeholder: Attributes.placeholder,
+            errorText: Attributes.errorText
         )
         super.init(nibName: nil, bundle: nil)
     }

--- a/QRIZ/Feature/FindAccount/ViewModel/FindIdViewModel.swift
+++ b/QRIZ/Feature/FindAccount/ViewModel/FindIdViewModel.swift
@@ -1,0 +1,54 @@
+//
+//  FindIdViewModel.swift
+//  QRIZ
+//
+//  Created by 김세훈 on 1/17/25.
+//
+
+import Foundation
+import Combine
+
+final class FindIdViewModel {
+    
+    // MARK: - Properties
+    
+    private let outputSubject: PassthroughSubject<Output, Never> = .init()
+    private var cancellables = Set<AnyCancellable>()
+    
+    // MARK: - Functions
+    
+    func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
+        input
+            .sink { [weak self] event in
+                guard let self = self else { return }
+                switch event {
+                case .emailTextChanged(let text):
+                    self.validateEmail(text)
+                    
+                case .buttonTapped:
+                    print("이메일 발송API 호출")
+                    outputSubject.send(.navigateToAlerView)
+                }
+            }
+            .store(in: &cancellables)
+        
+        return outputSubject.eraseToAnyPublisher()
+    }
+    
+    private func validateEmail(_ text: String) {
+        let isValid = text.isValidEmail
+        outputSubject.send(.isNameValid(isValid))
+    }
+}
+
+extension FindIdViewModel {
+    enum Input {
+        case emailTextChanged(String)
+        case buttonTapped
+    }
+    
+    enum Output {
+        case isNameValid(Bool)
+        case navigateToAlerView
+    }
+}

--- a/QRIZ/Feature/Login/ViewController/LoginViewController.swift
+++ b/QRIZ/Feature/Login/ViewController/LoginViewController.swift
@@ -74,6 +74,20 @@ final class LoginViewController: UIViewController {
                 switch output {
                 case .isLoginButtonEnabled(let isEnabled):
                     self.rootView.loginInputView.setLoginButtonEnabled(isEnabled)
+                    
+                case .navigateToAccountAction(let accountAction):
+                    // MARK: - 코디네이터 적용 필요
+                    let nextVC: UIViewController
+                    switch accountAction {
+                    case .findId:
+                        nextVC = FindIdViewController(findIdInputVM: FindIdViewModel())
+                    case .findPassword:
+                        nextVC = FindIdViewController(findIdInputVM: FindIdViewModel())
+                        print("패스워드뷰 호출(임시 아이디뷰 호출)")
+                    case .signUp:
+                        nextVC = NameInputViewController(nameInputVM: NameInputViewModel())
+                    }
+                    navigationController?.pushViewController(nextVC, animated: true)
                 }
             }
             .store(in: &cancellables)

--- a/QRIZ/Feature/Login/ViewModel/LoginViewModel.swift
+++ b/QRIZ/Feature/Login/ViewModel/LoginViewModel.swift
@@ -34,7 +34,7 @@ final class LoginViewModel {
                 case .loginButtonTapped:
                     print("ViewModel에서 로그인 버튼 클릭 이벤트를 입력 받았습니다.")
                 case .accountActionSelected(let action):
-                    self.handleAccountAction(action)
+                    self.outputSubject.send(.navigateToAccountAction(action))
                 case .socialLoginSelected(let socialLogin):
                     self.handleSocialLogin(socialLogin)
                 }
@@ -47,17 +47,6 @@ final class LoginViewModel {
     private func validateFields() {
         let isValid = id.isValidId && password.isValidPassword
         outputSubject.send(.isLoginButtonEnabled(isValid))
-    }
-    
-    private func handleAccountAction(_ action: AccountAction) {
-        switch action {
-        case .findId:
-            print("아이디 찾기 뷰로 이동")
-        case .findPassword:
-            print("비밀번호 찾기 뷰로 이동")
-        case .signUp:
-            print("회원가입 뷰로 이동")
-        }
     }
     
     private func handleSocialLogin(_ socialLogin: SocialLogin) {
@@ -84,6 +73,7 @@ extension LoginViewModel {
     
     enum Output {
         case isLoginButtonEnabled(Bool)
+        case navigateToAccountAction(AccountAction)
     }
     
     enum AccountAction: String {

--- a/QRIZ/Feature/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
+++ b/QRIZ/Feature/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
@@ -22,8 +22,7 @@ final class PreviewTestViewController: UIViewController {
     private let timeLabel: TestTimeLabel = TestTimeLabel()
     private let totalTimeRemainingLabel: TestTotalTimeRemainingLabel = TestTotalTimeRemainingLabel()
     private let pageIndicatorLabel: TestPageIndicatorLabel = TestPageIndicatorLabel()
-    private let submitAlert = CustomAlertView(alertType: .canCancel, title: "제출하시겠습니까", description: "확인 버튼을 누르면 다시 돌아올 수 없어요.", descriptionLine: 1)
-    private let submitAlertViewController = CustomAlertViewController()
+    private let submitAlertViewController = CustomAlertViewController(alertType: .canCancel, title: "제출하시겠습니까?", description: "확인 버튼을 누르면 다시 돌아올 수 없어요.")
     
     private let viewModel: PreviewTestViewModel = PreviewTestViewModel()
     private var subscriptions = Set<AnyCancellable>()
@@ -37,7 +36,7 @@ final class PreviewTestViewController: UIViewController {
         addViews()
         setOptionActions()
         setButtonActions()
-        setAlertController()
+        setAlertButtonActions()
         input.send(.viewDidLoad)
     }
     
@@ -82,20 +81,18 @@ final class PreviewTestViewController: UIViewController {
             .store(in: &subscriptions)
     }
     
-    private func setAlertController() {
-        setAlertButtonActions()
-        submitAlertViewController.setAlertView(alertView: submitAlert)
-    }
-    
     private func setAlertButtonActions() {
-        submitAlert.setButtonAction(true, action: UIAction(handler: { [weak self] _ in
+        let confirmAction = UIAction { [weak self] _ in
             guard let self = self else { return }
             self.input.send(.alertSubmitButtonClicked)
-        }))
-        submitAlert.setButtonAction(false, action: UIAction(handler: { [weak self] _ in
+        }
+        
+        let cancelAction = UIAction { [weak self] _ in
             guard let self = self else { return }
             self.input.send(.alertCancelButtonClicked)
-        }))
+        }
+        
+        submitAlertViewController.setupButtonActions(confirmAction: confirmAction, cancelAction: cancelAction)
     }
     
     private func setNavigationItem() {

--- a/QRIZ/Utils/Types/FindAccountType.swift
+++ b/QRIZ/Utils/Types/FindAccountType.swift
@@ -1,0 +1,31 @@
+//
+//  FindAccountType.swift
+//  QRIZ
+//
+//  Created by 김세훈 on 1/17/25.
+//
+
+import Foundation
+
+enum FindAccountType {
+    case findId
+    case findPassword
+    
+    var headerTitle: String {
+        switch self {
+        case .findId:
+            return "아이디를 잊으셨나요?"
+        case .findPassword:
+            return "비밀번호를 잊으셨나요?"
+        }
+    }
+    
+    var headerDescription: String {
+        switch self {
+        case .findId:
+            return "Qriz에 가입했던 이메일을 입력하시면\n아이디를 메일로 보내드립니다."
+        case .findPassword:
+            return "기존에 가입할때 사용한 이메일을 입력하시면\n비밀번호 변경 메일을 전송해드립니다."
+        }
+    }
+}


### PR DESCRIPTION
## 🛠️ Task
### 아이디찾기 뷰 UI 구현
- FindAccountHeaderView
- FindAccountInputView
- SignupFooterView(재사용)

###  아이디찾기 뷰 UI 로직 구현
- 이메일 유효성 검사 로직
- 유효성에 따른 SignupFooterView UI 업데이트 로직
- 이메일 발송 버튼 클릭 시 CustomAlertView로 결과 안내 로직 

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 아이디 찾기 뷰 |   <img src="https://github.com/user-attachments/assets/19c9efdd-ca73-41f6-bd30-b2a0f61a947a" alt="HTML Image" width="276.8" height="600"> |

## 📮 Issue 번호
- resolved: #21 