### PR TITLE
FEAT: 프리뷰 테스트 및 로직 수정

### DIFF
--- a/QRIZ/Feature/Onboarding/OnboardingComponents/OnboardingButton.swift
+++ b/QRIZ/Feature/Onboarding/OnboardingComponents/OnboardingButton.swift
@@ -17,11 +17,6 @@ final class OnboardingButton: UIButton {
         self.titleLabel?.font = UIFont.boldSystemFont(ofSize: 16)
         self.backgroundColor = .customBlue500
         self.layer.cornerRadius = 8
-
-        self.layer.shadowColor = UIColor.black.cgColor
-        self.layer.shadowOpacity = 0.1
-        self.layer.shadowOffset = CGSize(width: 4, height: 6)
-        self.layer.shadowRadius = 4
     }
     
     required init?(coder: NSCoder) {

--- a/QRIZ/Feature/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
+++ b/QRIZ/Feature/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
@@ -13,10 +13,10 @@ final class PreviewTestViewController: UIViewController {
     // MARK: - Properties
     private let questionNumberLabel = QuestionNumberLabel(0)
     private let questionTitleLabel = QuestionTitleLabel("")
-    private let option1Label = QuestionOptionLabel(optNum: 1, optStr: "")
-    private let option2Label = QuestionOptionLabel(optNum: 2, optStr: "")
-    private let option3Label = QuestionOptionLabel(optNum: 3, optStr: "")
-    private let option4Label = QuestionOptionLabel(optNum: 4, optStr: "")
+    private let option1Label = QuestionOptionLabel(optNum: 1)
+    private let option2Label = QuestionOptionLabel(optNum: 2)
+    private let option3Label = QuestionOptionLabel(optNum: 3)
+    private let option4Label = QuestionOptionLabel(optNum: 4)
     private let previousButton: TestButton = TestButton(isPreviousButton: true)
     private let nextButton: TestButton = TestButton(isPreviousButton: false)
     private let progressView: TestProgressView = TestProgressView()
@@ -226,22 +226,24 @@ extension PreviewTestViewController {
             progressView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
             progressView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
             progressView.heightAnchor.constraint(equalToConstant: 4),
+
             questionNumberLabel.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor, constant: 40),
             questionNumberLabel.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 18),
-            questionNumberLabel.widthAnchor.constraint(equalToConstant: 35),
-            questionNumberLabel.heightAnchor.constraint(equalToConstant: 30),
-            questionTitleLabel.topAnchor.constraint(equalTo: questionNumberLabel.topAnchor, constant: 5),
-            questionTitleLabel.leadingAnchor.constraint(equalTo: questionNumberLabel.trailingAnchor, constant: 9),
+
+            questionTitleLabel.topAnchor.constraint(equalTo: questionNumberLabel.bottomAnchor, constant: 14),
+            questionTitleLabel.leadingAnchor.constraint(equalTo: questionNumberLabel.leadingAnchor),
             questionTitleLabel.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -18),
-            questionTitleLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: 22),
+
             previousButton.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 18),
             previousButton.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -30),
             previousButton.widthAnchor.constraint(equalToConstant: 90),
             previousButton.heightAnchor.constraint(equalToConstant: 48),
+
             nextButton.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -18),
             nextButton.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -30),
             nextButton.widthAnchor.constraint(equalToConstant: 90),
             nextButton.heightAnchor.constraint(equalToConstant: 48),
+
             pageIndicatorLabel.centerYAnchor.constraint(equalTo: previousButton.centerYAnchor),
             pageIndicatorLabel.leadingAnchor.constraint(equalTo: previousButton.trailingAnchor),
             pageIndicatorLabel.trailingAnchor.constraint(equalTo: nextButton.leadingAnchor),
@@ -261,13 +263,12 @@ extension PreviewTestViewController {
             NSLayoutConstraint.activate([
                 option.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 18),
                 option.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -18),
-                option.heightAnchor.constraint(equalToConstant: 50),
             ])
             
-            if idx != 3 {
-                option.bottomAnchor.constraint(equalTo: optionLabels[idx + 1].topAnchor, constant: -8).isActive = true
+            if idx != 0 {
+                option.topAnchor.constraint(equalTo: optionLabels[idx - 1].bottomAnchor).isActive = true
             } else {
-                option4Label.bottomAnchor.constraint(equalTo: previousButton.topAnchor, constant:  -8).isActive = true
+                option1Label.topAnchor.constraint(equalTo: questionTitleLabel.bottomAnchor, constant: 26).isActive = true
             }
         }
     }

--- a/QRIZ/Feature/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
+++ b/QRIZ/Feature/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
@@ -29,6 +29,15 @@ final class PreviewTestViewController: UIViewController {
     private let progressView: TestProgressView = TestProgressView()
     private let timeLabel: TestTimeLabel = TestTimeLabel()
     private let totalTimeRemainingLabel: TestTotalTimeRemainingLabel = TestTotalTimeRemainingLabel()
+    private let pageIndicatorBgView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+
+        view.layer.shadowColor = UIColor.customBlue100.cgColor
+        view.layer.shadowOpacity = 1
+        view.layer.shadowRadius = 16
+        return view
+    }()
     private let pageIndicatorLabel: TestPageIndicatorLabel = TestPageIndicatorLabel()
     private let cancelLabel: UILabel = {
         let label = UILabel()
@@ -266,6 +275,7 @@ extension PreviewTestViewController {
         self.view.addSubview(progressView)
         self.view.addSubview(questionNumberLabel)
         self.view.addSubview(questionTitleLabel)
+        self.view.addSubview(pageIndicatorBgView)
         self.view.addSubview(previousButton)
         self.view.addSubview(nextButton)
         self.view.addSubview(pageIndicatorLabel)
@@ -273,6 +283,7 @@ extension PreviewTestViewController {
         progressView.translatesAutoresizingMaskIntoConstraints = false
         questionNumberLabel.translatesAutoresizingMaskIntoConstraints = false
         questionTitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        pageIndicatorBgView.translatesAutoresizingMaskIntoConstraints = false
         previousButton.translatesAutoresizingMaskIntoConstraints = false
         nextButton.translatesAutoresizingMaskIntoConstraints = false
         pageIndicatorLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -288,12 +299,17 @@ extension PreviewTestViewController {
             progressView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
             progressView.heightAnchor.constraint(equalToConstant: 4),
 
-            questionNumberLabel.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor, constant: 40),
             questionNumberLabel.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 18),
+            questionNumberLabel.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor, constant: 40),
 
-            questionTitleLabel.topAnchor.constraint(equalTo: questionNumberLabel.bottomAnchor, constant: 14),
             questionTitleLabel.leadingAnchor.constraint(equalTo: questionNumberLabel.leadingAnchor),
             questionTitleLabel.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -18),
+            questionTitleLabel.topAnchor.constraint(equalTo: questionNumberLabel.bottomAnchor, constant: 14),
+            
+            pageIndicatorBgView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            pageIndicatorBgView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            pageIndicatorBgView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -108),
+            pageIndicatorBgView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
 
             previousButton.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 18),
             previousButton.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -30),
@@ -305,9 +321,9 @@ extension PreviewTestViewController {
             nextButton.widthAnchor.constraint(equalToConstant: 90),
             nextButton.heightAnchor.constraint(equalToConstant: 48),
 
-            pageIndicatorLabel.centerYAnchor.constraint(equalTo: previousButton.centerYAnchor),
             pageIndicatorLabel.leadingAnchor.constraint(equalTo: previousButton.trailingAnchor),
             pageIndicatorLabel.trailingAnchor.constraint(equalTo: nextButton.leadingAnchor),
+            pageIndicatorLabel.centerYAnchor.constraint(equalTo: previousButton.centerYAnchor),
             pageIndicatorLabel.heightAnchor.constraint(equalToConstant: 22)
         ])
         

--- a/QRIZ/Feature/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
+++ b/QRIZ/Feature/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
@@ -11,12 +11,19 @@ import Combine
 final class PreviewTestViewController: UIViewController {
     
     // MARK: - Properties
+    private var selectedOptionIdx: Int? = nil
+    private var lastQuestionNum: Int = 0
+    private var curNum: Int = 0
+    
     private let questionNumberLabel = QuestionNumberLabel(0)
     private let questionTitleLabel = QuestionTitleLabel("")
-    private let option1Label = QuestionOptionLabel(optNum: 1)
-    private let option2Label = QuestionOptionLabel(optNum: 2)
-    private let option3Label = QuestionOptionLabel(optNum: 3)
-    private let option4Label = QuestionOptionLabel(optNum: 4)
+    private let optionLabels: [QuestionOptionLabel] = {
+        var arr: [QuestionOptionLabel] = []
+        for i in 1...4 {
+            arr.append(QuestionOptionLabel(optNum: i))
+        }
+        return arr
+    }()
     private let previousButton: TestButton = TestButton(isPreviousButton: true)
     private let nextButton: TestButton = TestButton(isPreviousButton: false)
     private let progressView: TestProgressView = TestProgressView()
@@ -62,16 +69,12 @@ final class PreviewTestViewController: UIViewController {
             .sink { [weak self] event in
                 guard let self = self else { return }
                 switch event {
-                case .selectOption(let idx):
-                    setOptionState(idx: idx, isSelected: true)
-                case .deselectOption(let idx):
-                    setOptionState(idx: idx, isSelected: false)
                 case .updateQuestion(let question):
                     updateQuestionUI(question: question)
+                case .updateLastQuestionNum(let num):
+                    self.lastQuestionNum = num
                 case .updateTime(let timeLimit, let timeRemaining):
                     updateProgress(timeLimit: timeLimit, timeRemaining: timeRemaining)
-                case .updateNextButton(let isLastQuestion):
-                    setNextButtonTitle(isLastQuestion: isLastQuestion)
                 case .moveToPreviewResult:
                     self.navigationController?.pushViewController(PreviewResultViewController(), animated: true)
                 case .moveToHome:
@@ -122,49 +125,82 @@ final class PreviewTestViewController: UIViewController {
         input.send(.escapeButtonClicked)
     }
     
+    private func updateQuestionUI(question: QuestionData) {
+        curNum = question.questionNumber
+        let optStringArr: [String] = [
+            question.option1, question.option2, question.option3, question.option4
+        ]
+
+        questionNumberLabel.setNumber(question.questionNumber)
+        questionTitleLabel.setTitle(question.question)
+        setSelectedOption(question.selectedOption)
+        setOptionsString(optStringArr)
+        pageIndicatorLabel.setPages(curPage: question.questionNumber, totalPage: lastQuestionNum)
+        setPageButtonsUI(question.questionNumber)
+    }
+}
+
+// MARK: - Methods For Options
+extension PreviewTestViewController {
+    private func setOptionsString(_ optStringArr: [String]) {
+        for i in 0...3 {
+            optionLabels[i].setOptionString(optStringArr[i])
+        }
+    }
+    
+    private func setSelectedOption(_ selectedOption: Int?) {
+        if let selectedOptionIdx = selectedOptionIdx {
+            setOptionState(idx: selectedOptionIdx, isSelected: false)
+        }
+        if let selectedOption = selectedOption {
+            setOptionState(idx: selectedOption, isSelected: true)
+        }
+        selectedOptionIdx = selectedOption
+    }
+    
     private func setOptionActions() {
-        
-        let optionLabels = [option1Label, option2Label, option3Label, option4Label]
-        
         for (index, optionLabel) in optionLabels.enumerated() {
             optionLabel.isUserInteractionEnabled = true
             optionLabel.tag = index + 1
-            let tapGesture = UITapGestureRecognizer(target: self, action: #selector(sendOptionTouchEvent(_:)))
+            let tapGesture = UITapGestureRecognizer(target: self, action: #selector(optionTouchEvent(_:)))
             optionLabel.addGestureRecognizer(tapGesture)
         }
     }
     
-    @objc private func sendOptionTouchEvent(_ sender: UITapGestureRecognizer) {
+    @objc private func optionTouchEvent(_ sender: UITapGestureRecognizer) {
+        guard let idx = sender.view?.tag else { return }
         
-        let idx = sender.view?.tag ?? 0
-        input.send(.optionSelected(idx: idx))
+        if let selectedOptionIdx = selectedOptionIdx {
+            if selectedOptionIdx == idx {
+                setOptionState(idx: idx, isSelected: false)
+                self.selectedOptionIdx = nil
+            } else {
+                setOptionState(idx: selectedOptionIdx, isSelected: false)
+                setOptionState(idx: idx, isSelected: true)
+                self.selectedOptionIdx = idx
+            }
+        } else {
+            setOptionState(idx: idx, isSelected: true)
+            self.selectedOptionIdx = idx
+        }
+        
+        if curNum == 1 {
+            selectedOptionIdx == nil ? setButtonsVisibility(isFirstQuestion: true, isOptionSelected: false) : setButtonsVisibility(isFirstQuestion: true, isOptionSelected: true)
+        }
     }
     
     private func setOptionState(idx: Int, isSelected: Bool) {
         switch idx {
-        case 1:
-            option1Label.setOptionStatus(isSelected: isSelected)
-        case 2:
-            option2Label.setOptionStatus(isSelected: isSelected)
-        case 3:
-            option3Label.setOptionStatus(isSelected: isSelected)
-        case 4:
-            option4Label.setOptionStatus(isSelected: isSelected)
+        case 1...4:
+            optionLabels[idx - 1].setOptionState(isSelected: isSelected)
         default:
             print("error occured while setting option state in PreviewTestViewController")
         }
     }
-    
-    private func updateQuestionUI(question: QuestionData) {
-        questionNumberLabel.setNumber(question.questionNumber)
-        questionTitleLabel.setTitle(question.question)
-        option1Label.setOptionString(question.option1)
-        option2Label.setOptionString(question.option2)
-        option3Label.setOptionString(question.option3)
-        option4Label.setOptionString(question.option4)
-        pageIndicatorLabel.setPages(curPage: question.questionNumber, totalPage: 20)
-    }
-    
+}
+
+// MARK: - Methods For Progress
+extension PreviewTestViewController {
     private func updateProgress(timeLimit: Int, timeRemaining: Int) {
         progressView.progress = Float(timeRemaining) / Float(timeLimit)
         timeLabel.text = formattedTime(timeRemaining: timeRemaining)
@@ -175,16 +211,34 @@ final class PreviewTestViewController: UIViewController {
         let seconds = timeRemaining % 60
         return String(format: "%02d:%02d", minutes, seconds)
     }
-    
+}
+
+// MARK: - Methods For Previous & Next Button
+extension PreviewTestViewController {
     private func setButtonActions() {
         self.previousButton.addAction(UIAction(handler: { [weak self] _ in
             guard let self = self else { return }
-            self.input.send(.prevButtonClicked)
+            self.input.send(.prevButtonClicked(selectedOption: selectedOptionIdx))
         }), for: .touchUpInside)
         self.nextButton.addAction(UIAction(handler: { [weak self] _ in
             guard let self = self else { return }
-            self.input.send(.nextButtonClicked)
+            self.input.send(.nextButtonClicked(selectedOption: selectedOptionIdx))
         }), for: .touchUpInside)
+    }
+    
+    private func setPageButtonsUI(_ questionNum: Int) {
+        switch questionNum {
+        case 1:
+            selectedOptionIdx == nil ? setButtonsVisibility(isFirstQuestion: true, isOptionSelected: false) : setButtonsVisibility(isFirstQuestion: true, isOptionSelected: true)
+        case 2:
+            setButtonsVisibility(isFirstQuestion: false)
+        case lastQuestionNum - 1:
+            setNextButtonTitle(isLastQuestion: false)
+        case lastQuestionNum:
+            setNextButtonTitle(isLastQuestion: true)
+        default:
+            return
+        }
     }
     
     private func setNextButtonTitle(isLastQuestion: Bool) {
@@ -194,18 +248,24 @@ final class PreviewTestViewController: UIViewController {
             nextButton.setTitleText("다음")
         }
     }
+    
+    private func setButtonsVisibility(isFirstQuestion: Bool, isOptionSelected: Bool = false) {
+        if isFirstQuestion {
+            previousButton.isHidden = true
+            nextButton.isHidden = !isOptionSelected
+        } else {
+            previousButton.isHidden = false
+            nextButton.isHidden = false
+        }
+    }
 }
 
-// MARK: - AutoLayout
+// MARK: - Auto Layout
 extension PreviewTestViewController {
     private func addViews() {
         self.view.addSubview(progressView)
         self.view.addSubview(questionNumberLabel)
         self.view.addSubview(questionTitleLabel)
-        self.view.addSubview(option1Label)
-        self.view.addSubview(option2Label)
-        self.view.addSubview(option3Label)
-        self.view.addSubview(option4Label)
         self.view.addSubview(previousButton)
         self.view.addSubview(nextButton)
         self.view.addSubview(pageIndicatorLabel)
@@ -213,13 +273,14 @@ extension PreviewTestViewController {
         progressView.translatesAutoresizingMaskIntoConstraints = false
         questionNumberLabel.translatesAutoresizingMaskIntoConstraints = false
         questionTitleLabel.translatesAutoresizingMaskIntoConstraints = false
-        option1Label.translatesAutoresizingMaskIntoConstraints = false
-        option2Label.translatesAutoresizingMaskIntoConstraints = false
-        option3Label.translatesAutoresizingMaskIntoConstraints = false
-        option4Label.translatesAutoresizingMaskIntoConstraints = false
         previousButton.translatesAutoresizingMaskIntoConstraints = false
         nextButton.translatesAutoresizingMaskIntoConstraints = false
         pageIndicatorLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        for optionLabel in optionLabels {
+            self.view.addSubview(optionLabel)
+            optionLabel.translatesAutoresizingMaskIntoConstraints = false
+        }
         
         NSLayoutConstraint.activate([
             progressView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
@@ -256,9 +317,6 @@ extension PreviewTestViewController {
     }
     
     private func setOptionLabelLayout() {
-        
-        let optionLabels: [QuestionOptionLabel] = [option1Label, option2Label, option3Label, option4Label]
-        
         for (idx, option) in optionLabels.enumerated() {
             NSLayoutConstraint.activate([
                 option.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 18),
@@ -268,7 +326,7 @@ extension PreviewTestViewController {
             if idx != 0 {
                 option.topAnchor.constraint(equalTo: optionLabels[idx - 1].bottomAnchor).isActive = true
             } else {
-                option1Label.topAnchor.constraint(equalTo: questionTitleLabel.bottomAnchor, constant: 26).isActive = true
+                optionLabels[0].topAnchor.constraint(equalTo: questionTitleLabel.bottomAnchor, constant: 26).isActive = true
             }
         }
     }

--- a/QRIZ/Feature/Onboarding/PreviewTest/ViewModel/PreviewTestViewModel.swift
+++ b/QRIZ/Feature/Onboarding/PreviewTest/ViewModel/PreviewTestViewModel.swift
@@ -14,22 +14,19 @@ final class PreviewTestViewModel {
     enum Input {
         case viewDidLoad
         case viewDidAppear
-        case prevButtonClicked
-        case nextButtonClicked
-        case optionSelected(idx: Int)
+        case prevButtonClicked(selectedOption: Int?)
+        case nextButtonClicked(selectedOption: Int?)
         case escapeButtonClicked
         case alertSubmitButtonClicked
         case alertCancelButtonClicked
     }
     
     enum Output {
-        // case loadDataSuccess
-        // case loadDataFailed
-        case selectOption(idx: Int)
-        case deselectOption(idx: Int)
+        // case fetchDataSuccess
+        // case fetchDataFailed
         case updateQuestion(question: QuestionData)
+        case updateLastQuestionNum(num: Int)
         case updateTime(timeLimit: Int, timeRemaining: Int)
-        case updateNextButton(isLastQuestion: Bool)
         case moveToPreviewResult
         case moveToHome
         case popUpAlert
@@ -63,18 +60,18 @@ final class PreviewTestViewModel {
                 // fetch QuestionList
                 // fetch totalTimeLimit
                 currentNumber = 1
+                output.send(.updateLastQuestionNum(num: questionList.count))
                 output.send(.updateQuestion(question: questionList[0]))
             case .viewDidAppear:
-                // timer
                 guard let totalTimeLimit = totalTimeLimit else { return }
                 output.send(.updateTime(timeLimit: totalTimeLimit, timeRemaining: timeRemaining))
                 startTimer()
-            case .prevButtonClicked:
-                buttonActionHandler(isNextButton: false)
-            case .nextButtonClicked:
-                buttonActionHandler(isNextButton: true)
-            case .optionSelected(let idx):
-                optionSelectHandler(idx: idx)
+            case .prevButtonClicked(let selectedOption):
+                updateAnswer(selectedOption: selectedOption)
+                pageButtonsActionHandler(isNextButton: false)
+            case .nextButtonClicked(let selectedOption):
+                updateAnswer(selectedOption: selectedOption)
+                pageButtonsActionHandler(isNextButton: true)
             case .escapeButtonClicked:
                 exitTimer()
                 // coordinator role
@@ -97,68 +94,41 @@ final class PreviewTestViewModel {
         output.send(.moveToPreviewResult)
     }
     
-    private func buttonActionHandler(isNextButton: Bool) {
-        
+    private func updateAnswer(selectedOption: Int?) {
+        if let currentNumber {
+            questionList[currentNumber - 1].selectedOption = selectedOption
+        }
+    }
+    
+    private func pageButtonsActionHandler(isNextButton: Bool) {
         guard let curNum = currentNumber else { return }
-        
         if isNextButton {
             if curNum >= questionList.count {
                 output.send(.popUpAlert)
             } else {
-                if curNum == questionList.count - 1 {
-                    output.send(.updateNextButton(isLastQuestion: true))
-                }
-                currentNumber = curNum + 1
+                currentNumber! += 1
                 output.send(.updateQuestion(question: questionList[currentNumber! - 1]))
-                for i in 1...4 {
-                    output.send(.deselectOption(idx: i))
-                }
-                if let selectedOption = questionList[currentNumber! - 1].selectedOption {
-                    output.send(.selectOption(idx: selectedOption))
-                }
             }
         } else {
-            if curNum > 1 {
-                if curNum == questionList.count {
-                    output.send(.updateNextButton(isLastQuestion: false))
-                }
-                currentNumber = curNum - 1
-                output.send(.updateQuestion(question: questionList[currentNumber! - 1]))
-                for i in 1...4 {
-                    output.send(.deselectOption(idx: i))
-                }
-                if let selectedOption = questionList[currentNumber! - 1].selectedOption {
-                    output.send(.selectOption(idx: selectedOption))
-                }
-            }
+            currentNumber! -= 1
+            output.send(.updateQuestion(question: questionList[currentNumber! - 1]))
         }
     }
-    
-    private func optionSelectHandler(idx: Int) {
-        guard let currentNumber = currentNumber else { return }
-        if let selectedOption = questionList[currentNumber - 1].selectedOption {
-            if selectedOption == idx {
-                questionList[currentNumber - 1].selectedOption = nil
-                output.send(.deselectOption(idx: idx))
-            } else {
-                questionList[currentNumber - 1].selectedOption = idx
-                output.send(.deselectOption(idx: selectedOption))
-                output.send(.selectOption(idx: idx))
-            }
-        } else {
-            questionList[currentNumber - 1].selectedOption = idx
-            output.send(.selectOption(idx: idx))
-        }
-    }
-    
+}
+
+// MARK: - Methods For Timer
+extension PreviewTestViewModel {
     private func startTimer() {
         timer = Timer.scheduledTimer(timeInterval: 1.0, target: self, selector: #selector(updateTimer), userInfo: nil, repeats: true)
     }
     
     @objc func updateTimer() {
+        guard let totalTimeLimit = totalTimeLimit else {
+            exitTimer()
+            return
+        }
         if timeRemaining > 0 {
             timeRemaining -= 1
-            guard let totalTimeLimit = totalTimeLimit else { return }
             output.send(.updateTime(timeLimit: totalTimeLimit, timeRemaining: timeRemaining))
             print(totalTimeLimit, timeRemaining)
         } else {

--- a/QRIZ/Feature/Onboarding/PreviewTest/ViewModel/PreviewTestViewModel.swift
+++ b/QRIZ/Feature/Onboarding/PreviewTest/ViewModel/PreviewTestViewModel.swift
@@ -102,15 +102,10 @@ final class PreviewTestViewModel {
     
     private func pageButtonsActionHandler(isNextButton: Bool) {
         guard let curNum = currentNumber else { return }
-        if isNextButton {
-            if curNum >= questionList.count {
-                output.send(.popUpAlert)
-            } else {
-                currentNumber! += 1
-                output.send(.updateQuestion(question: questionList[currentNumber! - 1]))
-            }
+        if isNextButton && curNum >= questionList.count {
+            output.send(.popUpAlert)
         } else {
-            currentNumber! -= 1
+            currentNumber = curNum + 1
             output.send(.updateQuestion(question: questionList[currentNumber! - 1]))
         }
     }

--- a/QRIZ/Feature/TempViewController.swift
+++ b/QRIZ/Feature/TempViewController.swift
@@ -1,0 +1,29 @@
+//
+//  TempViewController.swift
+//  QRIZ
+//
+//  Created by ch on 2/28/25.
+//
+
+import UIKit
+
+class TempViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/QRIZ/Feature/TestComponents/QuestionOptionLabel.swift
+++ b/QRIZ/Feature/TestComponents/QuestionOptionLabel.swift
@@ -10,17 +10,15 @@ import UIKit
 final class QuestionOptionLabel: UILabel {
 
     // MARK: - Properties
-    var optionNumberLabel: UILabel = UILabel()
-    var optionStringLabel: UILabel = UILabel()
+    var optionNumberLabel: UILabel!
+    var optionStringLabel: UILabel!
     
     // MARK: - Initializers
-    init(optNum: Int, optStr: String) {
+    init(optNum: Int) {
         super.init(frame: .zero)
-        self.backgroundColor = .white
-        self.layer.cornerRadius = 8
-        self.layer.masksToBounds = true
         createNumberLabel(optNum)
-        createStringLabel(optStr)
+        createStringLabel()
+        setOptionStatus(isSelected: false)
         addViews()
     }
     
@@ -29,30 +27,8 @@ final class QuestionOptionLabel: UILabel {
     }
     
     // MARK: - Methods
-    private func createNumberLabel(_ optNum: Int) {
-        optionNumberLabel = UILabel()
-        optionNumberLabel.backgroundColor = .white
-        optionNumberLabel.text = "\(optNum)"
-        optionNumberLabel.textAlignment = .center
-        optionNumberLabel.font = .boldSystemFont(ofSize: 16)
-        optionNumberLabel.textColor = .coolNeutral600
-        optionNumberLabel.numberOfLines = 0
-        optionNumberLabel.layer.masksToBounds = true
-        optionNumberLabel.layer.cornerRadius = 16
-        optionNumberLabel.layer.borderColor = UIColor.coolNeutral600.cgColor
-        optionNumberLabel.layer.borderWidth = 1.2
-    }
-    
-    private func createStringLabel(_ optStr: String) {
-        optionStringLabel = UILabel()
-        optionStringLabel.text = optStr
-        optionStringLabel.font = .systemFont(ofSize: 14)
-        optionStringLabel.textColor = .coolNeutral800
-        optionStringLabel.numberOfLines = 1
-    }
-    
     func setOptionString(_ str: String) {
-        optionStringLabel.text = str
+        optionStringLabel.attributedText = formattedText(str)
     }
     
     func setOptionStatus(isSelected: Bool) {
@@ -60,19 +36,48 @@ final class QuestionOptionLabel: UILabel {
             self.backgroundColor = .customBlue100
             optionNumberLabel.backgroundColor = .customBlue500
             optionNumberLabel.textColor = .white
-            optionNumberLabel.layer.cornerRadius = 16
-            optionNumberLabel.layer.masksToBounds = true
+
             optionNumberLabel.layer.borderWidth = 0
-            optionStringLabel.textColor = .customBlue500
         } else {
             self.backgroundColor = .white
             optionNumberLabel.backgroundColor = .white
-            optionNumberLabel.textColor = .coolNeutral600
-            optionNumberLabel.layer.cornerRadius = 16
-            optionNumberLabel.layer.masksToBounds = true
+            optionNumberLabel.textColor = .coolNeutral700
+
             optionNumberLabel.layer.borderWidth = 1.2
-            optionStringLabel.textColor = .coolNeutral800
         }
+    }
+    
+    private func createNumberLabel(_ optNum: Int) {
+        optionNumberLabel = UILabel()
+        optionNumberLabel.text = "\(optNum)"
+        optionNumberLabel.textAlignment = .center
+        optionNumberLabel.font = .boldSystemFont(ofSize: 16)
+        optionNumberLabel.numberOfLines = 1
+
+        optionNumberLabel.layer.masksToBounds = true
+        optionNumberLabel.layer.cornerRadius = 20
+        optionNumberLabel.layer.borderColor = UIColor.coolNeutral700.cgColor
+        optionNumberLabel.layer.borderWidth = 1.25
+    }
+    
+    private func createStringLabel() {
+        optionStringLabel = UILabel()
+        optionStringLabel.textAlignment = .left
+        optionStringLabel.textColor = .coolNeutral700
+        optionStringLabel.font = .systemFont(ofSize: 16, weight: .regular)
+        optionStringLabel.numberOfLines = 0
+    }
+    
+    private func formattedText(_ string: String) -> NSAttributedString {
+        let string = NSMutableAttributedString(string: string)
+
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineBreakMode = .byTruncatingTail
+        paragraphStyle.lineSpacing = 8
+        
+        string.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: string.length))
+        
+        return string
     }
 }
 
@@ -86,14 +91,15 @@ extension QuestionOptionLabel {
         optionStringLabel.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
-            optionNumberLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 18),
-            optionNumberLabel.widthAnchor.constraint(equalToConstant: 32),
-            optionNumberLabel.heightAnchor.constraint(equalToConstant: 32),
+            optionNumberLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 8),
+            optionNumberLabel.widthAnchor.constraint(equalToConstant: 40),
+            optionNumberLabel.heightAnchor.constraint(equalTo: optionNumberLabel.widthAnchor),
             optionNumberLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-            optionStringLabel.leadingAnchor.constraint(equalTo: optionNumberLabel.trailingAnchor, constant: 18),
-            optionStringLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -18),
-            optionStringLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-            optionStringLabel.heightAnchor.constraint(lessThanOrEqualTo: self.heightAnchor)
+            
+            optionStringLabel.leadingAnchor.constraint(equalTo: optionNumberLabel.trailingAnchor, constant: 16),
+            optionStringLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -8),
+            optionStringLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: 16),
+            optionStringLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -16)
         ])
     }
 }

--- a/QRIZ/Feature/TestComponents/QuestionOptionLabel.swift
+++ b/QRIZ/Feature/TestComponents/QuestionOptionLabel.swift
@@ -33,7 +33,7 @@ final class QuestionOptionLabel: UILabel {
     
     func setOptionState(isSelected: Bool) {
         if isSelected {
-            self.backgroundColor = .customBlue100
+            self.backgroundColor = .customBlue500.withAlphaComponent(0.14)
             optionNumberLabel.backgroundColor = .customBlue500
             optionNumberLabel.textColor = .white
             optionNumberLabel.layer.borderWidth = 0

--- a/QRIZ/Feature/TestComponents/QuestionOptionLabel.swift
+++ b/QRIZ/Feature/TestComponents/QuestionOptionLabel.swift
@@ -10,15 +10,15 @@ import UIKit
 final class QuestionOptionLabel: UILabel {
 
     // MARK: - Properties
-    var optionNumberLabel: UILabel!
-    var optionStringLabel: UILabel!
+    private var optionNumberLabel: UILabel!
+    private var optionStringLabel: UILabel!
     
     // MARK: - Initializers
     init(optNum: Int) {
         super.init(frame: .zero)
         createNumberLabel(optNum)
         createStringLabel()
-        setOptionStatus(isSelected: false)
+        setOptionState(isSelected: false)
         addViews()
     }
     
@@ -31,18 +31,16 @@ final class QuestionOptionLabel: UILabel {
         optionStringLabel.attributedText = formattedText(str)
     }
     
-    func setOptionStatus(isSelected: Bool) {
+    func setOptionState(isSelected: Bool) {
         if isSelected {
             self.backgroundColor = .customBlue100
             optionNumberLabel.backgroundColor = .customBlue500
             optionNumberLabel.textColor = .white
-
             optionNumberLabel.layer.borderWidth = 0
         } else {
             self.backgroundColor = .white
             optionNumberLabel.backgroundColor = .white
             optionNumberLabel.textColor = .coolNeutral700
-
             optionNumberLabel.layer.borderWidth = 1.2
         }
     }

--- a/QRIZ/Utils/Model/TestModel/QuestionData.swift
+++ b/QRIZ/Utils/Model/TestModel/QuestionData.swift
@@ -39,7 +39,7 @@ struct QuestionData {
         for i in 0..<20 {
             var question: QuestionData
             if i % 3 == 0 {
-                question = QuestionData(question: "다음 SQL 결과로 맞게 연결된 것을 고르시오.", option1: "ㄱ NULL ㄴ NULL ㄷ NULL ㄹ NULL", option2: "ㄱ NULl ㄴ NULl ㄷ NULl ㄹ NULl", option3: "ㄱ NUll ㄴ NUll ㄷ NUll ㄹ NUll", option4: "ㄱ null ㄴ null ㄷ null ㄹ null", timeLimit: 70, questionNumber: i + 1)
+                question = QuestionData(question: "다음 중 엔터티 분류에 대한 설명으로 가장 올바른 것은?", option1: "기본 엔터티는 항상 발생 엔터티의 부모 엔터티가 된다.", option2: "중심 엔터티는 업무에서 중요한 엔터티만을 의미한다.", option3: "행위 엔터티는 두 개 이상의 엔터티로부터 발생되는 엔터티이다.", option4: "코드 엔터티는 반드시 기본 엔터티여야 한다.", timeLimit: 70, questionNumber: i + 1)
             } else if i % 3 == 1 {
                 question = QuestionData(question: "다음 중 트랜잭션 모델링에서 '긴 트랜잭션(Long Transaction)'을 처리하는 방법으로 가장 적절한 것은?", option1: "트랜잭션을 더 작은 단위로 분할", option2: "트랜잭션의 타임아웃 시간을 늘림", option3: "모든 데이터를 메모리에 로드", option4: "트랜잭션의 격리 수준을 낮춤", timeLimit: 70, questionNumber: i + 1)
             } else {

--- a/QRIZ/Utils/Model/TestModel/QuestionData.swift
+++ b/QRIZ/Utils/Model/TestModel/QuestionData.swift
@@ -14,9 +14,10 @@ struct QuestionData {
     var option3: String
     var option4: String
     var timeLimit: Int
-
     var questionNumber: Int
     var selectedOption: Int? = nil
+    var description: String? = nil
+    var skillId: Int? = nil
     
     func getOptionRawValue(option: Int) -> String {
         switch option {


### PR DESCRIPTION
## 🛠️ Task

- 변경된 프리뷰 테스트 디자인에 맞게 구현
- 프리뷰 테스트 로직 개선
- 타이머 로직 수정

## 🌱 PR Point

- 프리뷰 테스트의 수정된 각 컴포넌트의 크기 및 색상, 오토레이아웃 및 navigation item 뿐만 아니라, 첫 문제에서의 버튼 존재 여부에 대해서도 변경됐습니다.
- 기존에 타이머의 시간을 직접 제공하는 방식에서, 처음 타이머가 켜졌을 때부터의 시간을 1초마다 구해서 남은 시간을 제공하도록 변경했습니다.

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 아무런 선택지가 선택되지 않은 1번 문제 | ![Simulator Screenshot - iPhone 15 Pro - 2025-03-07 at 21 10 35](https://github.com/user-attachments/assets/93513dad-5b64-47ed-be6d-ef8353a72651) |
| 선택지가 선택된 1번 문제 | ![Simulator Screenshot - iPhone 15 Pro - 2025-03-07 at 21 10 41](https://github.com/user-attachments/assets/5f4e7469-2fc1-4775-9e56-575540a2515f) |
| 2번문제 | ![Simulator Screenshot - iPhone 15 Pro - 2025-03-07 at 21 10 54](https://github.com/user-attachments/assets/a737b121-a88b-4c4c-bd32-9486dfd01588) |

## 📮 Issue 번호
- resolved: #32 
