### PR TITLE
FIX: 오늘의 공부 디자인 수정

### DIFF
--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -94,7 +94,6 @@
 		E24907D82D61A289004D6E61 /* DailyLearnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24907D72D61A289004D6E61 /* DailyLearnType.swift */; };
 		E24907DA2D63698C004D6E61 /* DailyLearnSectionTitleLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24907D92D63698C004D6E61 /* DailyLearnSectionTitleLabel.swift */; };
 		E24907DE2D6648A7004D6E61 /* DailyTestState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24907DD2D6648A7004D6E61 /* DailyTestState.swift */; };
-		E24907E02D66603A004D6E61 /* StudyContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24907DF2D66603A004D6E61 /* StudyContentView.swift */; };
 		E25856D42D0D766900355667 /* CheckConceptViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25856D32D0D766900355667 /* CheckConceptViewController.swift */; };
 		E25856DE2D0DADD300355667 /* BeginOnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25856DD2D0DADD300355667 /* BeginOnboardingViewModel.swift */; };
 		E25907C82D80732C0093121C /* PreviewResultScoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25907C72D80732C0093121C /* PreviewResultScoreView.swift */; };
@@ -104,6 +103,7 @@
 		E25F94CD2D0CB50F00BA765F /* OnboardingSubtitleLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25F94CC2D0CB50F00BA765F /* OnboardingSubtitleLabel.swift */; };
 		E25F94D12D0CB74700BA765F /* OnboardingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25F94D02D0CB74700BA765F /* OnboardingButton.swift */; };
 		E27E54A92D6D74C500BF3B55 /* CheckListFoldButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27E54A82D6D74C500BF3B55 /* CheckListFoldButton.swift */; };
+		E28A93852D945F95006A15DB /* StudyContentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28A93842D945F94006A15DB /* StudyContentCell.swift */; };
 		E28BAD772D2C111100B8388D /* TwoButtonCustomAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28BAD762D2C111100B8388D /* TwoButtonCustomAlertView.swift */; };
 		E28BAD792D2C2DEB00B8388D /* TwoButtonCustomAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28BAD782D2C2DEB00B8388D /* TwoButtonCustomAlertViewController.swift */; };
 		E28BAD7C2D2C339100B8388D /* AlertType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28BAD7B2D2C339100B8388D /* AlertType.swift */; };
@@ -256,7 +256,6 @@
 		E24907D72D61A289004D6E61 /* DailyLearnType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyLearnType.swift; sourceTree = "<group>"; };
 		E24907D92D63698C004D6E61 /* DailyLearnSectionTitleLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyLearnSectionTitleLabel.swift; sourceTree = "<group>"; };
 		E24907DD2D6648A7004D6E61 /* DailyTestState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyTestState.swift; sourceTree = "<group>"; };
-		E24907DF2D66603A004D6E61 /* StudyContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyContentView.swift; sourceTree = "<group>"; };
 		E25856D32D0D766900355667 /* CheckConceptViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CheckConceptViewController.swift; path = QRIZ/Feature/Onboarding/CheckConcept/ViewController/CheckConceptViewController.swift; sourceTree = SOURCE_ROOT; };
 		E25856DD2D0DADD300355667 /* BeginOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeginOnboardingViewModel.swift; sourceTree = "<group>"; };
 		E25907C72D80732C0093121C /* PreviewResultScoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewResultScoreView.swift; sourceTree = "<group>"; };
@@ -266,6 +265,7 @@
 		E25F94CC2D0CB50F00BA765F /* OnboardingSubtitleLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSubtitleLabel.swift; sourceTree = "<group>"; };
 		E25F94D02D0CB74700BA765F /* OnboardingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingButton.swift; sourceTree = "<group>"; };
 		E27E54A82D6D74C500BF3B55 /* CheckListFoldButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckListFoldButton.swift; sourceTree = "<group>"; };
+		E28A93842D945F94006A15DB /* StudyContentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyContentCell.swift; sourceTree = "<group>"; };
 		E28BAD762D2C111100B8388D /* TwoButtonCustomAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoButtonCustomAlertView.swift; sourceTree = "<group>"; };
 		E28BAD782D2C2DEB00B8388D /* TwoButtonCustomAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoButtonCustomAlertViewController.swift; sourceTree = "<group>"; };
 		E28BAD7B2D2C339100B8388D /* AlertType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertType.swift; sourceTree = "<group>"; };
@@ -774,7 +774,7 @@
 			isa = PBXGroup;
 			children = (
 				E24907D92D63698C004D6E61 /* DailyLearnSectionTitleLabel.swift */,
-				E24907DF2D66603A004D6E61 /* StudyContentView.swift */,
+				E28A93842D945F94006A15DB /* StudyContentCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1232,9 +1232,8 @@
 				B18F452C2D4D5CF00030F7DB /* ResetPasswordViewModel.swift in Sources */,
 				54C7A3102D146190001175D9 /* LoginViewController.swift in Sources */,
 				E29CCD3C2D298656004AA30A /* PreviewResultBarGraphsView.swift in Sources */,
-				E29CCD432D298656004AA30A /* ScoreCircularChartHostingController.swift in Sources */,
 				B19C4FBF2D6B6E3400CD008A /* MistakeNoteViewController.swift in Sources */,
-				E29CCD3C2D298656004AA30A /* BarGraphsView.swift in Sources */,
+				E29CCD3C2D298656004AA30A /* PreviewResultBarGraphsView.swift in Sources */,
 				54DB0DA12D0951C000ABD458 /* Font+.swift in Sources */,
 				B168B76D2D2824BD0000F32E /* IDInputViewController.swift in Sources */,
 				B17FE3062D27F85C002EC7D7 /* LoginViewModel.swift in Sources */,
@@ -1249,7 +1248,6 @@
 				E29CCD4A2D29867F004AA30A /* GreetingViewModel.swift in Sources */,
 				E29CCD3D2D298656004AA30A /* PreviewResultViewHostingController.swift in Sources */,
 				B1D813772D6E0CD700A9D447 /* MyPageCoordinator.swift in Sources */,
-				E29CCD3D2D298656004AA30A /* ConceptBarGraphHostingController.swift in Sources */,
 				B19C4FB92D6B15B300CD008A /* MyPageViewController.swift in Sources */,
 				E29CCD2F2D29855B004AA30A /* TestTimeLabel.swift in Sources */,
 				B168B7732D2846C80000F32E /* PasswordInputViewController.swift in Sources */,
@@ -1325,7 +1323,6 @@
 				E25F94CD2D0CB50F00BA765F /* OnboardingSubtitleLabel.swift in Sources */,
 				B18F45202D4643B40030F7DB /* FindPasswordVerificationMainView.swift in Sources */,
 				54BC61572D18141B0094DC45 /* AccountOptionsView.swift in Sources */,
-				E24907E02D66603A004D6E61 /* StudyContentView.swift in Sources */,
 				E29CCD1E2D298316004AA30A /* PreviewTestViewModel.swift in Sources */,
 				E29CCD442D298656004AA30A /* PreviewResultScoreCircularChartView.swift in Sources */,
 				B18F452E2D4D5D640030F7DB /* ResetPasswordMainView.swift in Sources */,
@@ -1333,6 +1330,7 @@
 				E24907D82D61A289004D6E61 /* DailyLearnType.swift in Sources */,
 				B168B76F2D2826010000F32E /* IDInputMainView.swift in Sources */,
 				B16288182D2CDB85008057D0 /* NameInputViewModel.swift in Sources */,
+				E28A93852D945F95006A15DB /* StudyContentCell.swift in Sources */,
 				B168B7632D28073C0000F32E /* NameInputMainView.swift in Sources */,
 				54BC61552D14AFB70094DC45 /* LoginInputView.swift in Sources */,
 				E24907DA2D63698C004D6E61 /* DailyLearnSectionTitleLabel.swift in Sources */,

--- a/QRIZ/Feature/CommonViews/TestNavigatorButton.swift
+++ b/QRIZ/Feature/CommonViews/TestNavigatorButton.swift
@@ -59,6 +59,7 @@ final class TestNavigatorButton: UIView {
         backgroundColor = .white
         setLayer()
         addViews()
+        addLongPress()
     }
     
     required init?(coder: NSCoder) {
@@ -146,6 +147,22 @@ final class TestNavigatorButton: UIView {
     
     private func updateTestTitleLabel(examRound: Int) {
         testTitleLabel.text = "\(examRound)회차"
+    }
+    
+    private func addLongPress() {
+        isUserInteractionEnabled = true
+        addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress)))
+    }
+    
+    @objc private func handleLongPress(_ sender: UIGestureRecognizer) {
+        switch sender.state {
+        case .began:
+            self.backgroundColor = .coolNeutral800.withAlphaComponent(0.1)
+        case .cancelled, .failed, .ended:
+            self.backgroundColor = .white
+        default:
+            break
+        }
     }
 }
 

--- a/QRIZ/Feature/DailyLearn/View/StudyContentCell.swift
+++ b/QRIZ/Feature/DailyLearn/View/StudyContentCell.swift
@@ -1,0 +1,91 @@
+//
+//  StudyContentCell.swift
+//  QRIZ
+//
+//  Created by ch on 3/27/25.
+//
+
+import UIKit
+
+final class StudyContentCell: UICollectionViewCell {
+    
+    // MARK: - Properties
+    static let identifier: String = "StudyContentCell"
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .coolNeutral800
+        label.numberOfLines = 1
+        label.textAlignment = .left
+        label.font = .systemFont(ofSize: 18, weight: .bold)
+        return label
+    }()
+    private let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .coolNeutral500
+        label.numberOfLines = 0
+        label.textAlignment = .left
+        label.font = .systemFont(ofSize: 14, weight: .regular)
+        return label
+    }()
+    private let conceptBookNavigator: UILabel = {
+        let label = UILabel()
+        label.textColor = .coolNeutral600
+        label.numberOfLines = 1
+        label.textAlignment = .left
+        label.font = .systemFont(ofSize: 14, weight: .bold)
+        label.attributedText = NSAttributedString(string: "개념서에서 보기＞", attributes: [
+            .underlineStyle: NSUnderlineStyle.single.rawValue
+        ])
+        return label
+    }()
+    
+    // MARK: - Initializers
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .white
+        self.layer.cornerRadius = 8
+        addViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("no initializer for coder: StudyContentCell")
+    }
+    
+    // MARK: - Methods
+    func setLabelText(titleText: String, descriptionText: String) {
+        titleLabel.text = titleText
+        
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 4
+        let attributedString = NSMutableAttributedString(string: descriptionText)
+        attributedString.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: attributedString.length))
+        
+        descriptionLabel.attributedText = attributedString
+    }
+}
+
+// MARK: - Auto Layout
+extension StudyContentCell {
+    private func addViews() {
+        addSubview(titleLabel)
+        addSubview(descriptionLabel)
+        addSubview(conceptBookNavigator)
+        
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
+        conceptBookNavigator.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: 20),
+            titleLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
+            
+            descriptionLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 12),
+            descriptionLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
+            descriptionLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -16),
+            
+            conceptBookNavigator.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor, constant: 12),
+            conceptBookNavigator.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16)
+        ])
+    }
+}

--- a/QRIZ/Feature/DailyLearn/View/StudyContentCell.swift
+++ b/QRIZ/Feature/DailyLearn/View/StudyContentCell.swift
@@ -28,24 +28,13 @@ final class StudyContentCell: UICollectionViewCell {
         label.font = .systemFont(ofSize: 14, weight: .regular)
         return label
     }()
-    private let conceptBookNavigator: UILabel = {
-        let label = UILabel()
-        label.textColor = .coolNeutral600
-        label.numberOfLines = 1
-        label.textAlignment = .left
-        label.font = .systemFont(ofSize: 14, weight: .bold)
-        label.attributedText = NSAttributedString(string: "개념서에서 보기＞", attributes: [
-            .underlineStyle: NSUnderlineStyle.single.rawValue
-        ])
-        label.isUserInteractionEnabled = true
-        return label
-    }()
     
     // MARK: - Initializers
     override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = .white
-        self.layer.cornerRadius = 8
+        setBorder()
+        addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress)))
         addViews()
     }
     
@@ -65,13 +54,22 @@ final class StudyContentCell: UICollectionViewCell {
         descriptionLabel.attributedText = attributedString
     }
     
-    func addTapGesture() {
-        conceptBookNavigator.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(moveToConceptBook)))
+    private func setBorder() {
+        self.layer.cornerRadius = 8
+        self.layer.shadowOpacity = 1
+        self.layer.shadowRadius = 8
+        self.layer.shadowColor = UIColor.coolNeutral100.cgColor
     }
     
-    @objc private func moveToConceptBook() {
-        guard let concept = titleLabel.text else { return }
-        print("Move To ConceptBook: \(concept)")
+    @objc private func handleLongPress(_ sender: UIGestureRecognizer) {
+        switch sender.state {
+        case .began:
+            self.backgroundColor = .coolNeutral800.withAlphaComponent(0.1)
+        case .cancelled, .failed, .ended:
+            self.backgroundColor = .white
+        default:
+            break
+        }
     }
 }
 
@@ -80,11 +78,9 @@ extension StudyContentCell {
     private func addViews() {
         addSubview(titleLabel)
         addSubview(descriptionLabel)
-        addSubview(conceptBookNavigator)
         
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
-        conceptBookNavigator.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
             titleLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: 20),
@@ -93,9 +89,6 @@ extension StudyContentCell {
             descriptionLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 12),
             descriptionLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
             descriptionLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -16),
-            
-            conceptBookNavigator.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -25),
-            conceptBookNavigator.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16)
         ])
     }
 }

--- a/QRIZ/Feature/DailyLearn/View/StudyContentCell.swift
+++ b/QRIZ/Feature/DailyLearn/View/StudyContentCell.swift
@@ -23,7 +23,7 @@ final class StudyContentCell: UICollectionViewCell {
     private let descriptionLabel: UILabel = {
         let label = UILabel()
         label.textColor = .coolNeutral500
-        label.numberOfLines = 0
+        label.numberOfLines = 2
         label.textAlignment = .left
         label.font = .systemFont(ofSize: 14, weight: .regular)
         return label
@@ -37,6 +37,7 @@ final class StudyContentCell: UICollectionViewCell {
         label.attributedText = NSAttributedString(string: "개념서에서 보기＞", attributes: [
             .underlineStyle: NSUnderlineStyle.single.rawValue
         ])
+        label.isUserInteractionEnabled = true
         return label
     }()
     
@@ -63,6 +64,15 @@ final class StudyContentCell: UICollectionViewCell {
         
         descriptionLabel.attributedText = attributedString
     }
+    
+    func addTapGesture() {
+        conceptBookNavigator.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(moveToConceptBook)))
+    }
+    
+    @objc private func moveToConceptBook() {
+        guard let concept = titleLabel.text else { return }
+        print("Move To ConceptBook: \(concept)")
+    }
 }
 
 // MARK: - Auto Layout
@@ -84,7 +94,7 @@ extension StudyContentCell {
             descriptionLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
             descriptionLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -16),
             
-            conceptBookNavigator.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor, constant: 12),
+            conceptBookNavigator.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -25),
             conceptBookNavigator.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16)
         ])
     }

--- a/QRIZ/Feature/DailyLearn/ViewController/DailyLearnViewController.swift
+++ b/QRIZ/Feature/DailyLearn/ViewController/DailyLearnViewController.swift
@@ -125,6 +125,36 @@ final class DailyLearnViewController: UIViewController {
     }
 }
 
+// MARK: - CollectionView DataSource & Delegate
+extension DailyLearnViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: StudyContentCell.identifier, for: indexPath) as? StudyContentCell else {
+            print("Failed to create StudyContentCell")
+            return UICollectionViewCell()
+        }
+
+        cell.setLabelText(titleText: "\(indexPath.item + 1). \(conceptArr[indexPath.item].0)",
+                          descriptionText: "·  \(conceptArr[indexPath.item].1)")
+        cell.addTapGesture()
+
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return conceptArr.count
+    }
+}
+
+extension DailyLearnViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: collectionView.frame.width, height: 150)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 16
+    }
+}
+
 // MARK: - Auto Layout
 extension DailyLearnViewController {
     private func addViews() {
@@ -181,34 +211,5 @@ extension DailyLearnViewController {
     private func setNavigatorButtonHeight(state: DailyTestState) {
         let buttonHeight = (state == .retestRequired ? 153.0 : 116.0)
         testNavigator.heightAnchor.constraint(equalToConstant: buttonHeight).isActive = true
-    }
-}
-
-// MARK: - CollectionView DataSource & Delegate
-extension DailyLearnViewController: UICollectionViewDataSource {
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: StudyContentCell.identifier, for: indexPath) as? StudyContentCell else {
-            print("Failed to create StudyContentCell")
-            return UICollectionViewCell()
-        }
-
-        cell.setLabelText(titleText: "\(indexPath.item + 1). \(conceptArr[indexPath.item].0)",
-                          descriptionText: "·  \(conceptArr[indexPath.item].1)")
-
-        return cell
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return conceptArr.count
-    }
-}
-
-extension DailyLearnViewController: UICollectionViewDelegateFlowLayout {
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: collectionView.frame.width, height: 150)
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        return 16
     }
 }

--- a/QRIZ/Feature/DailyLearn/ViewController/DailyLearnViewController.swift
+++ b/QRIZ/Feature/DailyLearn/ViewController/DailyLearnViewController.swift
@@ -21,6 +21,7 @@ final class DailyLearnViewController: UIViewController {
     private let studyContentView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
         collectionView.backgroundColor = .customBlue50
+        collectionView.layer.masksToBounds = false
         return collectionView
     }()
     private let testSubtextLabel: UILabel = {
@@ -135,7 +136,6 @@ extension DailyLearnViewController: UICollectionViewDataSource {
 
         cell.setLabelText(titleText: "\(indexPath.item + 1). \(conceptArr[indexPath.item].0)",
                           descriptionText: "·  \(conceptArr[indexPath.item].1)")
-        cell.addTapGesture()
 
         return cell
     }
@@ -147,11 +147,17 @@ extension DailyLearnViewController: UICollectionViewDataSource {
 
 extension DailyLearnViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: collectionView.frame.width, height: 150)
+        return CGSize(width: collectionView.frame.width, height: 116)
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         return 16
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        if conceptArr.count != 0 {
+            print(conceptArr[indexPath.item].0)
+        }
     }
 }
 

--- a/QRIZ/Feature/DailyLearn/ViewController/DailyLearnViewController.swift
+++ b/QRIZ/Feature/DailyLearn/ViewController/DailyLearnViewController.swift
@@ -18,7 +18,11 @@ final class DailyLearnViewController: UIViewController {
     }()
     private let scrollInnerView: UIView = .init()
     private let studyContentTitleLabel: DailyLearnSectionTitleLabel = .init()
-    private let studyContentView: StudyContentView = .init()
+    private let studyContentView: UICollectionView = {
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        collectionView.backgroundColor = .customBlue50
+        return collectionView
+    }()
     private let testSubtextLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 14, weight: .regular)
@@ -34,6 +38,8 @@ final class DailyLearnViewController: UIViewController {
     private let input: PassthroughSubject<DailyLearnViewModel.Input, Never> = .init()
     private var subscriptions = Set<AnyCancellable>()
     
+    private var conceptArr: [(String, String)] = []
+    
     // MARK: - Initializer
     init(dailyLearnViewModel: DailyLearnViewModel) {
         self.viewModel = dailyLearnViewModel
@@ -48,6 +54,7 @@ final class DailyLearnViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setNavigationBarTitle(title: "오늘의 공부")
+        setCollectionViewDataSourceAndDelegate()
         bind()
         input.send(.viewDidLoad)
         addViews()
@@ -68,8 +75,9 @@ final class DailyLearnViewController: UIViewController {
                     setNavigatorButtonHeight(state: state)
                 case .fetchFailed:
                     print("Fetch Failed")
-                case .updateContent(let keyConcept1, let conceptContent1, let keyConcept2, let conceptContent2):
-                    studyContentView.setLabelsText(keyConcept1: keyConcept1, conceptContent1: conceptContent1, keyConcept2: keyConcept2, conceptContent2: conceptContent2)
+                case .updateContent(let conceptArr):
+                    self.conceptArr = conceptArr
+                    updateCollectionViewHeight()
                 case .moveToDailyTest(let isRetest):
                     // modal will be added
                     print("MOVE TO DAILY TEST")
@@ -102,6 +110,18 @@ final class DailyLearnViewController: UIViewController {
     
     private func setNavigatorButton(state: DailyTestState, type: DailyLearnType, score: Int?) {
         testNavigator.setDailyUI(state: state, type: type, score: score)
+    }
+    
+    private func setCollectionViewDataSourceAndDelegate() {
+        studyContentView.register(StudyContentCell.self, forCellWithReuseIdentifier: StudyContentCell.identifier)
+        studyContentView.dataSource = self
+        studyContentView.delegate = self
+    }
+    
+    private func updateCollectionViewHeight() {
+        studyContentView.reloadData()
+        studyContentView.layoutIfNeeded()
+        studyContentView.heightAnchor.constraint(equalToConstant: studyContentView.contentSize.height).isActive = true
     }
 }
 
@@ -161,5 +181,34 @@ extension DailyLearnViewController {
     private func setNavigatorButtonHeight(state: DailyTestState) {
         let buttonHeight = (state == .retestRequired ? 153.0 : 116.0)
         testNavigator.heightAnchor.constraint(equalToConstant: buttonHeight).isActive = true
+    }
+}
+
+// MARK: - CollectionView DataSource & Delegate
+extension DailyLearnViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: StudyContentCell.identifier, for: indexPath) as? StudyContentCell else {
+            print("Failed to create StudyContentCell")
+            return UICollectionViewCell()
+        }
+
+        cell.setLabelText(titleText: "\(indexPath.item + 1). \(conceptArr[indexPath.item].0)",
+                          descriptionText: "·  \(conceptArr[indexPath.item].1)")
+
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return conceptArr.count
+    }
+}
+
+extension DailyLearnViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: collectionView.frame.width, height: 150)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 16
     }
 }

--- a/QRIZ/Feature/DailyLearn/ViewModel/DailyLearnViewModel.swift
+++ b/QRIZ/Feature/DailyLearn/ViewModel/DailyLearnViewModel.swift
@@ -32,6 +32,7 @@ final class DailyLearnViewModel {
     private var state: DailyTestState = .unavailable
     private var type: DailyLearnType = .daily
     private var score: Int? = nil
+    private var conceptArr: [(String, String)] = []
     
     private let output: PassthroughSubject<Output, Never> = .init()
     private var subscriptions = Set<AnyCancellable>()
@@ -57,12 +58,20 @@ final class DailyLearnViewModel {
     }
     
     private func fetchData() {
+        requestMockData()
         // will be replaced to network code && update properties
-        output.send(.fetchSuccess(state: .retestRequired, type: .daily, score: 30))
-        output.send(.updateContent(conceptArr: [
+        output.send(.fetchSuccess(state: state, type: type, score: score))
+        output.send(.updateContent(conceptArr: conceptArr))
+    }
+    
+    private func requestMockData() {
+        state = .retestRequired
+        type = .daily
+        score = 30
+        conceptArr = [
             ("데이터 모델의 이해", "JOIN은 두 개 이상의 테이블을 연결하여 데이터를 출력하는 것을 의미한다."),
             ("엔터티", "JOIN은 두 개 이상의 테이블을 연결하여 데이터를 출력하는 것을 의미한다.")
-            ]))
+        ]
     }
     
     private func handleNavigateAction() {

--- a/QRIZ/Feature/DailyLearn/ViewModel/DailyLearnViewModel.swift
+++ b/QRIZ/Feature/DailyLearn/ViewModel/DailyLearnViewModel.swift
@@ -21,11 +21,7 @@ final class DailyLearnViewModel {
                           type: DailyLearnType,
                           score: Int?
         )
-        case updateContent(keyConcept1: String,
-                           conceptContent1: String,
-                           keyConcept2: String, 
-                           conceptContent2: String
-        )
+        case updateContent(conceptArr: [(String, String)])
         case fetchFailed
         case moveToDailyTest(isRetest: Bool)
         case moveToDailyTestResult
@@ -36,10 +32,6 @@ final class DailyLearnViewModel {
     private var state: DailyTestState = .unavailable
     private var type: DailyLearnType = .daily
     private var score: Int? = nil
-    private var keyConcept1: String = ""
-    private var keyConcept2: String = ""
-    private var conceptContent1: String = ""
-    private var conceptContent2: String = ""
     
     private let output: PassthroughSubject<Output, Never> = .init()
     private var subscriptions = Set<AnyCancellable>()
@@ -67,7 +59,10 @@ final class DailyLearnViewModel {
     private func fetchData() {
         // will be replaced to network code && update properties
         output.send(.fetchSuccess(state: .retestRequired, type: .daily, score: 30))
-        output.send(.updateContent(keyConcept1: "데이터베이스", conceptContent1: "• JOIN은 두 개 이상의 테이블을 연결하여 데이터를 출력하는 것을 의미한다.\n• JOIN은 두 개 이상의 테이블을 연결하여 데이터를 출력하는 것을 의미한다.\n• JOIN은 두 개 이상의 테이블을 연결하여 데이터를 출력하는 것을 의미한다.\n• JOIN은 두 개 이상의 테이블을 연결하여 데이터를 출력하는 것을 의미한다.", keyConcept2: "데이터베이스", conceptContent2: "• JOIN은 두 개 이상의 테이블을 연결하여 데이터를 출력하는 것을 의미한다.\n• JOIN은 두 개 이상의 테이블을 연결하여 데이터를 출력하는 것을 의미한다.\n• JOIN은 두 개 이상의 테이블을 연결하여 데이터를 출력하는 것을 의미한다.\n• JOIN은 두 개 이상의 테이블을 연결하여 데이터를 출력하는 것을 의미한다."))
+        output.send(.updateContent(conceptArr: [
+            ("데이터 모델의 이해", "JOIN은 두 개 이상의 테이블을 연결하여 데이터를 출력하는 것을 의미한다."),
+            ("엔터티", "JOIN은 두 개 이상의 테이블을 연결하여 데이터를 출력하는 것을 의미한다.")
+            ]))
     }
     
     private func handleNavigateAction() {


### PR DESCRIPTION
## 🛠️ Task

- 오늘의 공부 디자인 수정

## 🌱 PR Point

- 하나의 컴포넌트로 이루어져있던 공부 내용 부분을, 개념별로 컬렉션뷰를 통해 여러 셀로 나누고 클릭 시 이동할 수 있도록 수정했습니다. (현재는 프린트문 출력으로 대체)
- 각 개념 셀에 그림자 효과를 적용했습니다.
- 각 개념셀에 UILongPressGestureRecognizer를 통해 꾹 눌렀을 때 배경 색상이 달라지도록 적용했습니다.
- 공부 내용 부분을 튜플 배열통해 주간 복습, 종합 복습 시 여러 개념이 등장할 수 있도록 적용했습니다.

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 수정된 기본 뷰 | ![Simulator Screenshot - iPhone 15 Pro - 2025-03-28 at 17 14 05](https://github.com/user-attachments/assets/783b2f02-d6f4-40a9-b779-59c94c944e62) |
| 여러 개념 등장 시 | ![Simulator Screenshot - iPhone 15 Pro - 2025-03-28 at 17 15 08](https://github.com/user-attachments/assets/680100a4-5cfa-46f8-aa01-a82438222cfa) |

## 📮 Issue 번호
- resolved: #38 
