### PR TITLE
FEAT: 데일리 테스트 뷰 구현

### DIFF
--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		E28BAD792D2C2DEB00B8388D /* TwoButtonCustomAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28BAD782D2C2DEB00B8388D /* TwoButtonCustomAlertViewController.swift */; };
 		E28BAD7C2D2C339100B8388D /* AlertType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28BAD7B2D2C339100B8388D /* AlertType.swift */; };
 		E2908E602DA2C49E00B8E81B /* DailyTestTimerLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2908E5F2DA2C49E00B8E81B /* DailyTestTimerLabel.swift */; };
+		E2908E622DAF5B8400B8E81B /* Int+.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2908E612DAF5B8400B8E81B /* Int+.swift */; };
 		E2939CA32D9D605C00F7E704 /* DailyTestContentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2939CA22D9D605C00F7E704 /* DailyTestContentsView.swift */; };
 		E29BF8552D117CF1006DC6D0 /* SurveyCheckList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E29BF8542D117CF1006DC6D0 /* SurveyCheckList.swift */; };
 		E29BF86D2D16895B006DC6D0 /* QuestionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E29BF86C2D16895B006DC6D0 /* QuestionData.swift */; };
@@ -287,6 +288,7 @@
 		E28BAD782D2C2DEB00B8388D /* TwoButtonCustomAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoButtonCustomAlertViewController.swift; sourceTree = "<group>"; };
 		E28BAD7B2D2C339100B8388D /* AlertType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertType.swift; sourceTree = "<group>"; };
 		E2908E5F2DA2C49E00B8E81B /* DailyTestTimerLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyTestTimerLabel.swift; sourceTree = "<group>"; };
+		E2908E612DAF5B8400B8E81B /* Int+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+.swift"; sourceTree = "<group>"; };
 		E2939CA22D9D605C00F7E704 /* DailyTestContentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyTestContentsView.swift; sourceTree = "<group>"; };
 		E29BF8542D117CF1006DC6D0 /* SurveyCheckList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyCheckList.swift; sourceTree = "<group>"; };
 		E29BF86C2D16895B006DC6D0 /* QuestionData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionData.swift; sourceTree = "<group>"; };
@@ -494,6 +496,7 @@
 				B18F45192D4139B00030F7DB /* UILabel+.swift */,
 				B19C4F6A2D5260DD00CD008A /* UIControl+.swift */,
 				B19C4F6C2D5262D900CD008A /* Combine+.swift */,
+				E2908E612DAF5B8400B8E81B /* Int+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1363,6 +1366,7 @@
 				541878542D0E21620089F478 /* HTTPMethod.swift in Sources */,
 				B18F45222D4645EC0030F7DB /* VerificationInputView.swift in Sources */,
 				548566502D1241A4002BAEE3 /* ExampleRequest.swift in Sources */,
+				E2908E622DAF5B8400B8E81B /* Int+.swift in Sources */,
 				E29CCD422D298656004AA30A /* PreviewResultViewModel.swift in Sources */,
 				548566522D1241BA002BAEE3 /* ExampleResponse.swift in Sources */,
 				548566492D123C94002BAEE3 /* NetworkRequest.swift in Sources */,

--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -108,10 +108,12 @@
 		E25F94CD2D0CB50F00BA765F /* OnboardingSubtitleLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25F94CC2D0CB50F00BA765F /* OnboardingSubtitleLabel.swift */; };
 		E25F94D12D0CB74700BA765F /* OnboardingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25F94D02D0CB74700BA765F /* OnboardingButton.swift */; };
 		E27E54A92D6D74C500BF3B55 /* CheckListFoldButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27E54A82D6D74C500BF3B55 /* CheckListFoldButton.swift */; };
+		E283AC082D9E8D8F00DE005B /* DailyTestDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E283AC072D9E8D8F00DE005B /* DailyTestDescriptionView.swift */; };
 		E28A93852D945F95006A15DB /* StudyContentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28A93842D945F94006A15DB /* StudyContentCell.swift */; };
 		E28BAD772D2C111100B8388D /* TwoButtonCustomAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28BAD762D2C111100B8388D /* TwoButtonCustomAlertView.swift */; };
 		E28BAD792D2C2DEB00B8388D /* TwoButtonCustomAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28BAD782D2C2DEB00B8388D /* TwoButtonCustomAlertViewController.swift */; };
 		E28BAD7C2D2C339100B8388D /* AlertType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28BAD7B2D2C339100B8388D /* AlertType.swift */; };
+		E2939CA32D9D605C00F7E704 /* DailyTestContentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2939CA22D9D605C00F7E704 /* DailyTestContentsView.swift */; };
 		E29BF8552D117CF1006DC6D0 /* SurveyCheckList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E29BF8542D117CF1006DC6D0 /* SurveyCheckList.swift */; };
 		E29BF86D2D16895B006DC6D0 /* QuestionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E29BF86C2D16895B006DC6D0 /* QuestionData.swift */; };
 		E29CCD1C2D298303004AA30A /* PreviewTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E29CCD1B2D298303004AA30A /* PreviewTestViewController.swift */; };
@@ -278,10 +280,12 @@
 		E26AF7022D918F03006E3252 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		E26AF7032D918F07006E3252 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Shared.xcconfig; sourceTree = "<group>"; };
 		E27E54A82D6D74C500BF3B55 /* CheckListFoldButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckListFoldButton.swift; sourceTree = "<group>"; };
+		E283AC072D9E8D8F00DE005B /* DailyTestDescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyTestDescriptionView.swift; sourceTree = "<group>"; };
 		E28A93842D945F94006A15DB /* StudyContentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyContentCell.swift; sourceTree = "<group>"; };
 		E28BAD762D2C111100B8388D /* TwoButtonCustomAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoButtonCustomAlertView.swift; sourceTree = "<group>"; };
 		E28BAD782D2C2DEB00B8388D /* TwoButtonCustomAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoButtonCustomAlertViewController.swift; sourceTree = "<group>"; };
 		E28BAD7B2D2C339100B8388D /* AlertType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertType.swift; sourceTree = "<group>"; };
+		E2939CA22D9D605C00F7E704 /* DailyTestContentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyTestContentsView.swift; sourceTree = "<group>"; };
 		E29BF8542D117CF1006DC6D0 /* SurveyCheckList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyCheckList.swift; sourceTree = "<group>"; };
 		E29BF86C2D16895B006DC6D0 /* QuestionData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionData.swift; sourceTree = "<group>"; };
 		E29CCD1B2D298303004AA30A /* PreviewTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewTestViewController.swift; sourceTree = "<group>"; };
@@ -766,6 +770,8 @@
 			isa = PBXGroup;
 			children = (
 				E217C36F2D9BF2860095A3D8 /* DailyTestFooterView.swift */,
+				E2939CA22D9D605C00F7E704 /* DailyTestContentsView.swift */,
+				E283AC072D9E8D8F00DE005B /* DailyTestDescriptionView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1392,6 +1398,7 @@
 				B18F45152D3A40BE0030F7DB /* FindAccountType.swift in Sources */,
 				E239630B2D083B900092B39B /* SceneDelegate.swift in Sources */,
 				E2D70FEC2D0EBDDD005A3F51 /* CheckListCell.swift in Sources */,
+				E283AC082D9E8D8F00DE005B /* DailyTestDescriptionView.swift in Sources */,
 				E28BAD772D2C111100B8388D /* TwoButtonCustomAlertView.swift in Sources */,
 				E29CCD2E2D29855B004AA30A /* TestProgressView.swift in Sources */,
 				E28BAD7C2D2C339100B8388D /* AlertType.swift in Sources */,
@@ -1399,6 +1406,7 @@
 				E2DD0E842D2144D000DA3D18 /* PreviewConceptsData.swift in Sources */,
 				E29CCD302D29855B004AA30A /* TestTotalTimeRemainingLabel.swift in Sources */,
 				E29CCD2D2D29855B004AA30A /* TestPageIndicatorLabel.swift in Sources */,
+				E2939CA32D9D605C00F7E704 /* DailyTestContentsView.swift in Sources */,
 				E25856DE2D0DADD300355667 /* BeginOnboardingViewModel.swift in Sources */,
 				E230669A2D2126B9001B509A /* PreviewScoresData.swift in Sources */,
 				B1D9A0E72D3686BA00E84934 /* CountdownTimer.swift in Sources */,

--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -79,6 +79,11 @@
 		B1D813772D6E0CD700A9D447 /* MyPageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D813762D6E0CD700A9D447 /* MyPageCoordinator.swift */; };
 		B1D8137A2D768D9B00A9D447 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D813792D768D9B00A9D447 /* AppCoordinator.swift */; };
 		B1D9A0E72D3686BA00E84934 /* CountdownTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D9A0E62D3686BA00E84934 /* CountdownTimer.swift */; };
+		E217C3622D9BEA8D0095A3D8 /* DailyTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E217C3612D9BEA8D0095A3D8 /* DailyTestViewController.swift */; };
+		E217C3662D9BEAC50095A3D8 /* DailyTestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E217C3652D9BEAC50095A3D8 /* DailyTestViewModel.swift */; };
+		E217C3692D9BF0B20095A3D8 /* DailyResultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E217C3682D9BF0B20095A3D8 /* DailyResultViewModel.swift */; };
+		E217C36B2D9BF0C30095A3D8 /* DailyResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E217C36A2D9BF0C30095A3D8 /* DailyResultViewController.swift */; };
+		E217C3702D9BF2860095A3D8 /* DailyTestFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E217C36F2D9BF2860095A3D8 /* DailyTestFooterView.swift */; };
 		E230669A2D2126B9001B509A /* PreviewScoresData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23066992D2126B9001B509A /* PreviewScoresData.swift */; };
 		E23824E12D0C3157009E7989 /* BeginOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23824E02D0C3157009E7989 /* BeginOnboardingViewController.swift */; };
 		E23963092D083B900092B39B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23963082D083B900092B39B /* AppDelegate.swift */; };
@@ -236,6 +241,11 @@
 		B1D813762D6E0CD700A9D447 /* MyPageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCoordinator.swift; sourceTree = "<group>"; };
 		B1D813792D768D9B00A9D447 /* AppCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		B1D9A0E62D3686BA00E84934 /* CountdownTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountdownTimer.swift; sourceTree = "<group>"; };
+		E217C3612D9BEA8D0095A3D8 /* DailyTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyTestViewController.swift; sourceTree = "<group>"; };
+		E217C3652D9BEAC50095A3D8 /* DailyTestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyTestViewModel.swift; sourceTree = "<group>"; };
+		E217C3682D9BF0B20095A3D8 /* DailyResultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyResultViewModel.swift; sourceTree = "<group>"; };
+		E217C36A2D9BF0C30095A3D8 /* DailyResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyResultViewController.swift; sourceTree = "<group>"; };
+		E217C36F2D9BF2860095A3D8 /* DailyTestFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyTestFooterView.swift; sourceTree = "<group>"; };
 		E23066992D2126B9001B509A /* PreviewScoresData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewScoresData.swift; sourceTree = "<group>"; };
 		E23824E02D0C3157009E7989 /* BeginOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeginOnboardingViewController.swift; sourceTree = "<group>"; };
 		E23963052D083B8F0092B39B /* QRIZ.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QRIZ.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -426,6 +436,8 @@
 		54DB0D962D09506C00ABD458 /* Feature */ = {
 			isa = PBXGroup;
 			children = (
+				E217C3672D9BF0A10095A3D8 /* DailyResult */,
+				E217C35F2D9BEA500095A3D8 /* DailyTest */,
 				54E91B742D18FA9600474D0A /* CommonViews */,
 				B19C4FC32D6C223E00CD008A /* TabBar */,
 				E29CCD282D29855B004AA30A /* TestComponents */,
@@ -697,6 +709,65 @@
 				B1D9A0E62D3686BA00E84934 /* CountdownTimer.swift */,
 			);
 			path = Manager;
+			sourceTree = "<group>";
+		};
+		E217C35F2D9BEA500095A3D8 /* DailyTest */ = {
+			isa = PBXGroup;
+			children = (
+				E217C36E2D9BF2660095A3D8 /* View */,
+				E217C3642D9BEAA40095A3D8 /* ViewModel */,
+				E217C3632D9BEA900095A3D8 /* ViewController */,
+			);
+			path = DailyTest;
+			sourceTree = "<group>";
+		};
+		E217C3632D9BEA900095A3D8 /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				E217C3612D9BEA8D0095A3D8 /* DailyTestViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
+		E217C3642D9BEAA40095A3D8 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				E217C3652D9BEAC50095A3D8 /* DailyTestViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		E217C3672D9BF0A10095A3D8 /* DailyResult */ = {
+			isa = PBXGroup;
+			children = (
+				E217C36D2D9BF0CF0095A3D8 /* ViewModel */,
+				E217C36C2D9BF0C60095A3D8 /* ViewController */,
+			);
+			path = DailyResult;
+			sourceTree = "<group>";
+		};
+		E217C36C2D9BF0C60095A3D8 /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				E217C36A2D9BF0C30095A3D8 /* DailyResultViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
+		E217C36D2D9BF0CF0095A3D8 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				E217C3682D9BF0B20095A3D8 /* DailyResultViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		E217C36E2D9BF2660095A3D8 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				E217C36F2D9BF2860095A3D8 /* DailyTestFooterView.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 		E23824DF2D0C1FA7009E7989 /* Onboarding */ = {
@@ -1275,6 +1346,7 @@
 				E29CCD292D29855B004AA30A /* QuestionNumberLabel.swift in Sources */,
 				E2D70FEE2D0EC037005A3F51 /* CheckConceptViewModel.swift in Sources */,
 				E29CCD2C2D29855B004AA30A /* TestButton.swift in Sources */,
+				E217C3692D9BF0B20095A3D8 /* DailyResultViewModel.swift in Sources */,
 				B168B75F2D28073C0000F32E /* SignupFooterView.swift in Sources */,
 				B162881C2D2CFC63008057D0 /* UIView+.swift in Sources */,
 				E27E54A92D6D74C500BF3B55 /* CheckListFoldButton.swift in Sources */,
@@ -1306,6 +1378,7 @@
 				B168B7692D2807470000F32E /* SignUpVerificationViewController.swift in Sources */,
 				54E91B762D18FACD00474D0A /* RoundButton.swift in Sources */,
 				54DB0D992D0950DE00ABD458 /* HomeViewModel.swift in Sources */,
+				E217C3622D9BEA8D0095A3D8 /* DailyTestViewController.swift in Sources */,
 				B17FE30A2D27F8E9002EC7D7 /* UITextField+.swift in Sources */,
 				B19C4FC52D6C226500CD008A /* TabBarCoordinator.swift in Sources */,
 				E29CCD4C2D299297004AA30A /* SwiftUIViews+.swift in Sources */,
@@ -1332,6 +1405,7 @@
 				B18F45102D3997280030F7DB /* FindAccountHeaderView.swift in Sources */,
 				E29BF8552D117CF1006DC6D0 /* SurveyCheckList.swift in Sources */,
 				E2DD0E862D2146D900DA3D18 /* IncorrectCountData.swift in Sources */,
+				E217C36B2D9BF0C30095A3D8 /* DailyResultViewController.swift in Sources */,
 				E24907D32D619F39004D6E61 /* DailyLearnViewModel.swift in Sources */,
 				E29CCD3E2D298656004AA30A /* PreviewResultConceptView.swift in Sources */,
 				E25F94CD2D0CB50F00BA765F /* OnboardingSubtitleLabel.swift in Sources */,
@@ -1346,8 +1420,10 @@
 				B16288182D2CDB85008057D0 /* NameInputViewModel.swift in Sources */,
 				E28A93852D945F95006A15DB /* StudyContentCell.swift in Sources */,
 				B168B7632D28073C0000F32E /* NameInputMainView.swift in Sources */,
+				E217C3702D9BF2860095A3D8 /* DailyTestFooterView.swift in Sources */,
 				54BC61552D14AFB70094DC45 /* LoginInputView.swift in Sources */,
 				E24907DA2D63698C004D6E61 /* DailyLearnSectionTitleLabel.swift in Sources */,
+				E217C3662D9BEAC50095A3D8 /* DailyTestViewModel.swift in Sources */,
 				B19C4F6B2D5260DD00CD008A /* UIControl+.swift in Sources */,
 				B1D813752D6E0CC900A9D447 /* MistakeNoteCoordinator.swift in Sources */,
 				B168B7752D2846DD0000F32E /* PasswordInputMainView.swift in Sources */,

--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		E28BAD772D2C111100B8388D /* TwoButtonCustomAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28BAD762D2C111100B8388D /* TwoButtonCustomAlertView.swift */; };
 		E28BAD792D2C2DEB00B8388D /* TwoButtonCustomAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28BAD782D2C2DEB00B8388D /* TwoButtonCustomAlertViewController.swift */; };
 		E28BAD7C2D2C339100B8388D /* AlertType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28BAD7B2D2C339100B8388D /* AlertType.swift */; };
+		E2908E602DA2C49E00B8E81B /* DailyTestTimerLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2908E5F2DA2C49E00B8E81B /* DailyTestTimerLabel.swift */; };
 		E2939CA32D9D605C00F7E704 /* DailyTestContentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2939CA22D9D605C00F7E704 /* DailyTestContentsView.swift */; };
 		E29BF8552D117CF1006DC6D0 /* SurveyCheckList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E29BF8542D117CF1006DC6D0 /* SurveyCheckList.swift */; };
 		E29BF86D2D16895B006DC6D0 /* QuestionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E29BF86C2D16895B006DC6D0 /* QuestionData.swift */; };
@@ -285,6 +286,7 @@
 		E28BAD762D2C111100B8388D /* TwoButtonCustomAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoButtonCustomAlertView.swift; sourceTree = "<group>"; };
 		E28BAD782D2C2DEB00B8388D /* TwoButtonCustomAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoButtonCustomAlertViewController.swift; sourceTree = "<group>"; };
 		E28BAD7B2D2C339100B8388D /* AlertType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertType.swift; sourceTree = "<group>"; };
+		E2908E5F2DA2C49E00B8E81B /* DailyTestTimerLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyTestTimerLabel.swift; sourceTree = "<group>"; };
 		E2939CA22D9D605C00F7E704 /* DailyTestContentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyTestContentsView.swift; sourceTree = "<group>"; };
 		E29BF8542D117CF1006DC6D0 /* SurveyCheckList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyCheckList.swift; sourceTree = "<group>"; };
 		E29BF86C2D16895B006DC6D0 /* QuestionData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionData.swift; sourceTree = "<group>"; };
@@ -772,6 +774,7 @@
 				E217C36F2D9BF2860095A3D8 /* DailyTestFooterView.swift */,
 				E2939CA22D9D605C00F7E704 /* DailyTestContentsView.swift */,
 				E283AC072D9E8D8F00DE005B /* DailyTestDescriptionView.swift */,
+				E2908E5F2DA2C49E00B8E81B /* DailyTestTimerLabel.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1440,6 +1443,7 @@
 				B19C4FA92D5D182600CD008A /* EmailVerificationViewModel.swift in Sources */,
 				B168B7612D28073C0000F32E /* SingleInputView.swift in Sources */,
 				54C7A3162D14A5A6001175D9 /* LoginLogoView.swift in Sources */,
+				E2908E602DA2C49E00B8E81B /* DailyTestTimerLabel.swift in Sources */,
 				B19C4FAD2D61304400CD008A /* OneButtonCustomAlertMainView.swift in Sources */,
 				54C7A3132D1461A6001175D9 /* LoginMainView.swift in Sources */,
 				B19C4F6F2D55DCA400CD008A /* SignUpVerificationMainView.swift in Sources */,

--- a/QRIZ/Feature/DailyResult/ViewController/DailyResultViewController.swift
+++ b/QRIZ/Feature/DailyResult/ViewController/DailyResultViewController.swift
@@ -8,9 +8,33 @@
 import UIKit
 
 final class DailyResultViewController: UIViewController {
+    
+    private let label: UILabel = {
+        let label = UILabel()
+        label.text = "데일리 테스트 결과"
+        label.textColor = .black
+        label.font = .systemFont(ofSize: 15)
+        label.backgroundColor = .white
+        return label
+    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.view.backgroundColor = .black
+        print("VIEWDIDLOAD")
+        addViews()
+    }
+}
+
+extension DailyResultViewController {
+    private func addViews() {
+        self.view.addSubview(label)
         
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+            label.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),
+        ])
     }
 }

--- a/QRIZ/Feature/DailyResult/ViewController/DailyResultViewController.swift
+++ b/QRIZ/Feature/DailyResult/ViewController/DailyResultViewController.swift
@@ -1,0 +1,16 @@
+//
+//  DailyResultViewController.swift
+//  QRIZ
+//
+//  Created by 이창현 on 4/1/25.
+//
+
+import UIKit
+
+final class DailyResultViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+    }
+}

--- a/QRIZ/Feature/DailyResult/ViewController/DailyResultViewController.swift
+++ b/QRIZ/Feature/DailyResult/ViewController/DailyResultViewController.swift
@@ -21,7 +21,6 @@ final class DailyResultViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = .black
-        print("VIEWDIDLOAD")
         addViews()
     }
 }

--- a/QRIZ/Feature/DailyResult/ViewModel/DailyResultViewModel.swift
+++ b/QRIZ/Feature/DailyResult/ViewModel/DailyResultViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  DailyResultViewModel.swift
+//  QRIZ
+//
+//  Created by 이창현 on 4/1/25.
+//
+
+import Foundation
+
+final  class DailyResultViewModel {
+    
+}

--- a/QRIZ/Feature/DailyTest/View/DailyTestContentsView.swift
+++ b/QRIZ/Feature/DailyTest/View/DailyTestContentsView.swift
@@ -1,0 +1,77 @@
+//
+//  DailyTestOptionsView.swift
+//  QRIZ
+//
+//  Created by 이창현 on 4/2/25.
+//
+
+import UIKit
+
+final class DailyTestContentsView: UIStackView {
+    
+    // MARK: - Properties
+    private let numberLabel: QuestionNumberLabel = .init()
+    private let titleLabel: QuestionTitleLabel = .init()
+    private let descriptionLabel: DailyTestDescriptionView = .init()
+    private let optionLabels: [QuestionOptionLabel] = {
+        var arr: [QuestionOptionLabel] = []
+        for i in 1...4 {
+            arr.append(QuestionOptionLabel(optNum: i))
+        }
+        return arr
+    }()
+    
+    // MARK: - Initializers
+    init() {
+        super.init(frame: .zero)
+        setupStack()
+        setMargins()
+        addViews()
+        addCustomSpacing()
+        setMockUI()
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError()
+    }
+    
+    // MARK: - Methods
+    private func setupStack() {
+        axis = .vertical
+        alignment = .leading
+        spacing = 32
+    }
+    
+    private func setMargins() {
+        isLayoutMarginsRelativeArrangement = true
+        layoutMargins = UIEdgeInsets(top: 35, left: 0, bottom: 35, right: 0)
+    }
+    
+    // MARK: - TEST
+    private func setMockUI() {
+        numberLabel.setNumber(1)
+        titleLabel.setTitle("데이터 모델링에서 '유연성'이 의미하는 바는?")
+        optionLabels[0].setOptionString("ㄱ. null ㄴ. NULL ㄷ. null ㄹ. NULL")
+        optionLabels[1].setOptionString("ㄱ. null ㄴ. NULL ㄷ. null ㄹ. NULL")
+        optionLabels[2].setOptionString("ㄱ. null ㄴ. NULL ㄷ. null ㄹ. NULL")
+        optionLabels[3].setOptionString("ㄱ. null ㄴ. NULL ㄷ. null ㄹ. NULL")
+    }
+}
+
+// MARK: - Layout
+extension DailyTestContentsView {
+    private func addViews() {
+        addArrangedSubview(numberLabel)
+        addArrangedSubview(titleLabel)
+        addArrangedSubview(descriptionLabel)
+        for option in optionLabels {
+            addArrangedSubview(option)
+        }
+    }
+    
+    private func addCustomSpacing() {
+        setCustomSpacing(8, after: numberLabel)
+        setCustomSpacing(10, after: titleLabel)
+        setCustomSpacing(8, after: numberLabel)
+    }
+}

--- a/QRIZ/Feature/DailyTest/View/DailyTestContentsView.swift
+++ b/QRIZ/Feature/DailyTest/View/DailyTestContentsView.swift
@@ -36,6 +36,22 @@ final class DailyTestContentsView: UIStackView {
     }
     
     // MARK: - Methods
+    func updateQuestion(_ question: QuestionData) {
+        numberLabel.setNumber(question.questionNumber)
+        titleLabel.setTitle(question.question)
+        if let description = question.description {
+            descriptionLabel.isHidden = false
+            descriptionLabel.setText(description)
+        } else {
+            descriptionLabel.isHidden = true
+        }
+        let options = [question.option1, question.option2, question.option3, question.option4]
+        for i in 0...3 {
+            optionLabels[i].setOptionState(isSelected: false)
+            optionLabels[i].setOptionString(options[i])
+        }
+    }
+    
     private func setupStack() {
         axis = .vertical
         alignment = .fill

--- a/QRIZ/Feature/DailyTest/View/DailyTestContentsView.swift
+++ b/QRIZ/Feature/DailyTest/View/DailyTestContentsView.swift
@@ -38,8 +38,7 @@ final class DailyTestContentsView: UIStackView {
     // MARK: - Methods
     private func setupStack() {
         axis = .vertical
-        alignment = .leading
-        spacing = 32
+        alignment = .fill
     }
     
     private func setMargins() {
@@ -50,11 +49,31 @@ final class DailyTestContentsView: UIStackView {
     // MARK: - TEST
     private func setMockUI() {
         numberLabel.setNumber(1)
-        titleLabel.setTitle("데이터 모델링에서 '유연성'이 의미하는 바는?")
-        optionLabels[0].setOptionString("ㄱ. null ㄴ. NULL ㄷ. null ㄹ. NULL")
-        optionLabels[1].setOptionString("ㄱ. null ㄴ. NULL ㄷ. null ㄹ. NULL")
-        optionLabels[2].setOptionString("ㄱ. null ㄴ. NULL ㄷ. null ㄹ. NULL")
-        optionLabels[3].setOptionString("ㄱ. null ㄴ. NULL ㄷ. null ㄹ. NULL")
+        titleLabel.setTitle("다음과 같은 상황에서 적절한 엔터티 도출 방식은?")
+        optionLabels[0].setOptionString("""
+                                        기본 엔터티: 고객, 상품
+                                        중심 엔터티: 주문
+                                        행위 엔터티: 주문상품
+                                        코드 엔터티: 주문상태
+                                        """)
+        optionLabels[1].setOptionString("""
+                                        기본 엔터티: 고객, 상품
+                                        중심 엔터티: 주문
+                                        행위 엔터티: 주문상품
+                                        코드 엔터티: 주문상태
+                                        """)
+        optionLabels[2].setOptionString("""
+                                        기본 엔터티: 고객, 상품
+                                        중심 엔터티: 주문
+                                        행위 엔터티: 주문상품
+                                        코드 엔터티: 주문상태
+                                        """)
+        optionLabels[3].setOptionString("""
+                                        기본 엔터티: 고객, 상품
+                                        중심 엔터티: 주문
+                                        행위 엔터티: 주문상품
+                                        코드 엔터티: 주문상태
+                                        """)
     }
 }
 
@@ -70,8 +89,8 @@ extension DailyTestContentsView {
     }
     
     private func addCustomSpacing() {
-        setCustomSpacing(8, after: numberLabel)
-        setCustomSpacing(10, after: titleLabel)
-        setCustomSpacing(8, after: numberLabel)
+        setCustomSpacing(14, after: numberLabel)
+        setCustomSpacing(14, after: titleLabel)
+        setCustomSpacing(16, after: descriptionLabel)
     }
 }

--- a/QRIZ/Feature/DailyTest/View/DailyTestDescriptionView.swift
+++ b/QRIZ/Feature/DailyTest/View/DailyTestDescriptionView.swift
@@ -24,13 +24,6 @@ final class DailyTestDescriptionView: UIView {
         super.init(frame: .zero)
         setBorder()
         addViews()
-        setAttributedText("""
-        [업무상황]
-        1. 고객이 상품을 주문한다.
-        2. 한 번의 주문에 여러 상품을 담을 수 있다.
-        3. 상품의 재고는 실시간으로 관리되어야 한다.
-        4. 주문 상태는 '주문', '결제', '배송', '완료'로 관리된다.
-        """)
     }
     
     required init?(coder: NSCoder) {
@@ -38,15 +31,15 @@ final class DailyTestDescriptionView: UIView {
     }
     
     // MARK: - Methods
+    func setText(_ text: String) {
+        label.attributedText = formattedText(text)
+    }
+    
     private func setBorder() {
         layer.cornerRadius = 8
         layer.masksToBounds = true
         layer.borderWidth = 1
         layer.borderColor = UIColor.coolNeutral200.cgColor
-    }
-    
-    private func setAttributedText(_ text: String) {
-        label.attributedText = formattedText(text)
     }
     
     private func formattedText(_ text: String) -> NSMutableAttributedString {

--- a/QRIZ/Feature/DailyTest/View/DailyTestDescriptionView.swift
+++ b/QRIZ/Feature/DailyTest/View/DailyTestDescriptionView.swift
@@ -14,9 +14,8 @@ final class DailyTestDescriptionView: UIView {
         let label = UILabel()
         label.numberOfLines = 0
         label.textAlignment = .left
-        label.font = .systemFont(ofSize: 14, weight: .medium)
+        label.font = .systemFont(ofSize: 12, weight: .medium)
         label.textColor = .black
-        label.text = "asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdf"
         return label
     }()
     
@@ -25,6 +24,13 @@ final class DailyTestDescriptionView: UIView {
         super.init(frame: .zero)
         setBorder()
         addViews()
+        setAttributedText("""
+        [업무상황]
+        1. 고객이 상품을 주문한다.
+        2. 한 번의 주문에 여러 상품을 담을 수 있다.
+        3. 상품의 재고는 실시간으로 관리되어야 한다.
+        4. 주문 상태는 '주문', '결제', '배송', '완료'로 관리된다.
+        """)
     }
     
     required init?(coder: NSCoder) {
@@ -37,6 +43,18 @@ final class DailyTestDescriptionView: UIView {
         layer.masksToBounds = true
         layer.borderWidth = 1
         layer.borderColor = UIColor.coolNeutral200.cgColor
+    }
+    
+    private func setAttributedText(_ text: String) {
+        label.attributedText = formattedText(text)
+    }
+    
+    private func formattedText(_ text: String) -> NSMutableAttributedString {
+        let attributedText = NSMutableAttributedString(string: text)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 4
+        attributedText.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: attributedText.length))
+        return attributedText
     }
 }
 

--- a/QRIZ/Feature/DailyTest/View/DailyTestDescriptionView.swift
+++ b/QRIZ/Feature/DailyTest/View/DailyTestDescriptionView.swift
@@ -1,0 +1,56 @@
+//
+//  DailyTestDescriptionView.swift
+//  QRIZ
+//
+//  Created by 이창현 on 4/3/25.
+//
+
+import UIKit
+
+final class DailyTestDescriptionView: UIView {
+    
+    // MARK: - Properties
+    private let label: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.textAlignment = .left
+        label.font = .systemFont(ofSize: 14, weight: .medium)
+        label.textColor = .black
+        label.text = "asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdf"
+        return label
+    }()
+    
+    // MARK: - Initializers
+    init() {
+        super.init(frame: .zero)
+        setBorder()
+        addViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    // MARK: - Methods
+    private func setBorder() {
+        layer.cornerRadius = 8
+        layer.masksToBounds = true
+        layer.borderWidth = 1
+        layer.borderColor = UIColor.coolNeutral200.cgColor
+    }
+}
+
+extension DailyTestDescriptionView {
+    private func addViews() {
+        addSubview(label)
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            label.topAnchor.constraint(equalTo: topAnchor, constant: 16),
+            label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -16)
+        ])
+    }
+}

--- a/QRIZ/Feature/DailyTest/View/DailyTestFooterView.swift
+++ b/QRIZ/Feature/DailyTest/View/DailyTestFooterView.swift
@@ -11,17 +11,17 @@ import Combine
 final class DailyTestFooterView: UIView {
     
     // MARK: - Properties
-    private let previousButton: TestButton = TestButton(isPreviousButton: true)
     private let nextButton: TestButton = TestButton(isPreviousButton: false)
     private let pageIndicatorLabel: TestPageIndicatorLabel = .init()
     
-    // Combine 추가 자리
+    let input: PassthroughSubject<DailyTestViewModel.Input, Never> = .init()
     
     // MARK: - Initializers
     init() {
         super.init(frame: .zero)
         setupUI()
         addViews()
+        addButtonAction()
     }
     
     required init?(coder: NSCoder) {
@@ -29,16 +29,18 @@ final class DailyTestFooterView: UIView {
     }
     
     // MARK: - Methods
-    func updatePage(curPage: Int, totalPage: Int) {
-        pageIndicatorLabel.setPages(curPage: curPage, totalPage: totalPage)
+    func updateCurPage(curPage: Int) {
+        pageIndicatorLabel.setCurPage(curPage: curPage)
+    }
+    
+    func updateTotalPage(totalPage: Int) {
+        pageIndicatorLabel.setTotalPage(totalPage: totalPage)
     }
     
     func setButtonsVisibility(isFirstQuestion: Bool, isOptionSelected: Bool = false) {
         if isFirstQuestion {
-            previousButton.isHidden = true
             nextButton.isHidden = !isOptionSelected
         } else {
-            previousButton.isHidden = false
             nextButton.isHidden = false
         }
     }
@@ -49,32 +51,32 @@ final class DailyTestFooterView: UIView {
         layer.shadowOpacity = 1
         layer.shadowRadius = 16
     }
+    
+    private func addButtonAction() {
+        nextButton.addAction(UIAction(handler: { [weak self] _ in
+            guard let self = self else { return }
+            self.input.send(.nextButtonClicked)
+        }), for: .touchUpInside)
+    }
 }
 
 // MARK: - Auto Layout
 extension DailyTestFooterView {
     private func addViews() {
-        addSubview(previousButton)
         addSubview(nextButton)
         addSubview(pageIndicatorLabel)
         
-        previousButton.translatesAutoresizingMaskIntoConstraints = false
         nextButton.translatesAutoresizingMaskIntoConstraints = false
         pageIndicatorLabel.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
-            previousButton.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 18),
-            previousButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -30),
-            previousButton.widthAnchor.constraint(equalToConstant: 90),
-            previousButton.heightAnchor.constraint(equalToConstant: 48),
-            
             nextButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -18),
-            nextButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -30),
+            nextButton.topAnchor.constraint(equalTo: self.topAnchor, constant: 17),
             nextButton.widthAnchor.constraint(equalToConstant: 90),
             nextButton.heightAnchor.constraint(equalToConstant: 48),
             
             pageIndicatorLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-            pageIndicatorLabel.centerYAnchor.constraint(equalTo: previousButton.centerYAnchor)
+            pageIndicatorLabel.centerYAnchor.constraint(equalTo: nextButton.centerYAnchor)
         ])
     }
 }

--- a/QRIZ/Feature/DailyTest/View/DailyTestFooterView.swift
+++ b/QRIZ/Feature/DailyTest/View/DailyTestFooterView.swift
@@ -37,12 +37,12 @@ final class DailyTestFooterView: UIView {
         pageIndicatorLabel.setTotalPage(totalPage: totalPage)
     }
     
-    func setButtonsVisibility(isFirstQuestion: Bool, isOptionSelected: Bool = false) {
-        if isFirstQuestion {
-            nextButton.isHidden = !isOptionSelected
-        } else {
-            nextButton.isHidden = false
-        }
+    func setButtonsVisibility(isVisible: Bool) {
+        nextButton.isHidden = !isVisible
+    }
+    
+    func alterButtonText() {
+        nextButton.setTitleText("제출")
     }
     
     private func setupUI() {

--- a/QRIZ/Feature/DailyTest/View/DailyTestFooterView.swift
+++ b/QRIZ/Feature/DailyTest/View/DailyTestFooterView.swift
@@ -50,6 +50,8 @@ final class DailyTestFooterView: UIView {
         layer.shadowColor = UIColor.customBlue100.cgColor
         layer.shadowOpacity = 1
         layer.shadowRadius = 16
+        layer.borderColor = UIColor.customBlue100.cgColor
+        layer.borderWidth = 1
     }
     
     private func addButtonAction() {

--- a/QRIZ/Feature/DailyTest/View/DailyTestFooterView.swift
+++ b/QRIZ/Feature/DailyTest/View/DailyTestFooterView.swift
@@ -12,7 +12,7 @@ final class DailyTestFooterView: UIView {
     
     // MARK: - Properties
     private let previousButton: TestButton = TestButton(isPreviousButton: true)
-    private let nextButton: TestButton = TestButton(isPreviousButton: true)
+    private let nextButton: TestButton = TestButton(isPreviousButton: false)
     private let pageIndicatorLabel: TestPageIndicatorLabel = .init()
     
     // Combine 추가 자리

--- a/QRIZ/Feature/DailyTest/View/DailyTestFooterView.swift
+++ b/QRIZ/Feature/DailyTest/View/DailyTestFooterView.swift
@@ -1,0 +1,80 @@
+//
+//  DailyTestFooterView.swift
+//  QRIZ
+//
+//  Created by 이창현 on 4/1/25.
+//
+
+import UIKit
+import Combine
+
+final class DailyTestFooterView: UIView {
+    
+    // MARK: - Properties
+    private let previousButton: TestButton = TestButton(isPreviousButton: true)
+    private let nextButton: TestButton = TestButton(isPreviousButton: true)
+    private let pageIndicatorLabel: TestPageIndicatorLabel = .init()
+    
+    // Combine 추가 자리
+    
+    // MARK: - Initializers
+    init() {
+        super.init(frame: .zero)
+        setupUI()
+        addViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    // MARK: - Methods
+    func updatePage(curPage: Int, totalPage: Int) {
+        pageIndicatorLabel.setPages(curPage: curPage, totalPage: totalPage)
+    }
+    
+    func setButtonsVisibility(isFirstQuestion: Bool, isOptionSelected: Bool = false) {
+        if isFirstQuestion {
+            previousButton.isHidden = true
+            nextButton.isHidden = !isOptionSelected
+        } else {
+            previousButton.isHidden = false
+            nextButton.isHidden = false
+        }
+    }
+    
+    private func setupUI() {
+        backgroundColor = .white
+        layer.shadowColor = UIColor.customBlue100.cgColor
+        layer.shadowOpacity = 1
+        layer.shadowRadius = 16
+    }
+}
+
+// MARK: - Auto Layout
+extension DailyTestFooterView {
+    private func addViews() {
+        addSubview(previousButton)
+        addSubview(nextButton)
+        addSubview(pageIndicatorLabel)
+        
+        previousButton.translatesAutoresizingMaskIntoConstraints = false
+        nextButton.translatesAutoresizingMaskIntoConstraints = false
+        pageIndicatorLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            previousButton.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 18),
+            previousButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -30),
+            previousButton.widthAnchor.constraint(equalToConstant: 90),
+            previousButton.heightAnchor.constraint(equalToConstant: 48),
+            
+            nextButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -18),
+            nextButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -30),
+            nextButton.widthAnchor.constraint(equalToConstant: 90),
+            nextButton.heightAnchor.constraint(equalToConstant: 48),
+            
+            pageIndicatorLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            pageIndicatorLabel.centerYAnchor.constraint(equalTo: previousButton.centerYAnchor)
+        ])
+    }
+}

--- a/QRIZ/Feature/DailyTest/View/DailyTestTimerLabel.swift
+++ b/QRIZ/Feature/DailyTest/View/DailyTestTimerLabel.swift
@@ -42,13 +42,8 @@ final class DailyTestTimerLabel: UILabel {
     
     // MARK: - Methods
     func updateTime(timeRemaining: Int) {
-        timerLabel.text = formattedTime(timeRemaining: timeRemaining)
-    }
-    
-    private func formattedTime(timeRemaining: Int) -> String {
-        let minutes = timeRemaining / 60
-        let seconds = timeRemaining % 60
-        return String(format: "%02d:%02d", minutes, seconds)
+//        timerLabel.text = formattedTime(timeRemaining: timeRemaining)
+        timerLabel.text = timeRemaining.formattedTime
     }
 }
 

--- a/QRIZ/Feature/DailyTest/View/DailyTestTimerLabel.swift
+++ b/QRIZ/Feature/DailyTest/View/DailyTestTimerLabel.swift
@@ -23,7 +23,7 @@ final class DailyTestTimerLabel: UILabel {
     private let timerLabel: UILabel = {
         let label = UILabel()
         label.textColor = .customRed500
-        label.font = .systemFont(ofSize: 14, weight: .semibold)
+        label.font = .monospacedDigitSystemFont(ofSize: 14, weight: .semibold)
         label.numberOfLines = 1
         label.backgroundColor = .white
         return label

--- a/QRIZ/Feature/DailyTest/View/DailyTestTimerLabel.swift
+++ b/QRIZ/Feature/DailyTest/View/DailyTestTimerLabel.swift
@@ -1,0 +1,72 @@
+//
+//  DailyTestTimerLabel.swift
+//  QRIZ
+//
+//  Created by ch on 4/6/25.
+//
+
+import UIKit
+
+final class DailyTestTimerLabel: UILabel {
+    
+    // MARK: - Properties
+    private let remainingTextLabel: UILabel = {
+        let label = UILabel()
+        label.text = "문제별 남은시간"
+        label.textColor = .coolNeutral700
+        label.font = .systemFont(ofSize: 14, weight: .regular)
+        label.numberOfLines = 1
+        label.backgroundColor = .white
+        return label
+    }()
+    
+    private let timerLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .customRed500
+        label.font = .systemFont(ofSize: 14, weight: .semibold)
+        label.numberOfLines = 1
+        label.backgroundColor = .white
+        return label
+    }()
+    
+    // MARK: - Initializers
+    init() {
+        super.init(frame: .zero)
+        updateTime(timeRemaining: 0)
+        addViews()
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("no initializer for coder: DailyTestTimerLabel")
+    }
+    
+    // MARK: - Methods
+    func updateTime(timeRemaining: Int) {
+        timerLabel.text = formattedTime(timeRemaining: timeRemaining)
+    }
+    
+    private func formattedTime(timeRemaining: Int) -> String {
+        let minutes = timeRemaining / 60
+        let seconds = timeRemaining % 60
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+}
+
+// MARK: - Auto Layout
+extension DailyTestTimerLabel {
+    private func addViews() {
+        addSubview(remainingTextLabel)
+        addSubview(timerLabel)
+        
+        remainingTextLabel.translatesAutoresizingMaskIntoConstraints = false
+        timerLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            timerLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            timerLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            
+            remainingTextLabel.trailingAnchor.constraint(equalTo: timerLabel.leadingAnchor, constant: -8),
+            remainingTextLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+        ])
+    }
+}

--- a/QRIZ/Feature/DailyTest/ViewController/DailyTestViewController.swift
+++ b/QRIZ/Feature/DailyTest/ViewController/DailyTestViewController.swift
@@ -1,0 +1,71 @@
+//
+//  DailyTestViewController.swift
+//  QRIZ
+//
+//  Created by 이창현 on 4/1/25.
+//
+
+import UIKit
+
+final class DailyTestViewController: UIViewController {
+    
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.backgroundColor = .white
+        return scrollView
+    }()
+    private let contentView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        return view
+    }()
+    private let progressView: TestProgressView = .init()
+    private let footerView: DailyTestFooterView = .init()
+    private let questionNumberLabe = QuestionNumberLabel(0)
+    private let questionTitleLabel = QuestionTitleLabel("")
+    
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .white
+        addViews()
+        progressView.progress = 0.3 // temp
+    }
+}
+
+// Auto Layout
+extension DailyTestViewController {
+    private func addViews() {
+        self.view.addSubview(progressView)
+        self.view.addSubview(footerView)
+        self.view.addSubview(scrollView)
+        scrollView.addSubview(contentView)
+        
+        progressView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        footerView.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            progressView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            progressView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            progressView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+            progressView.heightAnchor.constraint(equalToConstant: 4),
+            
+            footerView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            footerView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            footerView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
+            footerView.heightAnchor.constraint(equalToConstant: 108),
+            
+            scrollView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: progressView.bottomAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: footerView.topAnchor),
+            
+            contentView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            contentView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            contentView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+        ])
+    }
+}

--- a/QRIZ/Feature/DailyTest/ViewController/DailyTestViewController.swift
+++ b/QRIZ/Feature/DailyTest/ViewController/DailyTestViewController.swift
@@ -14,16 +14,9 @@ final class DailyTestViewController: UIViewController {
         scrollView.backgroundColor = .white
         return scrollView
     }()
-    private let contentView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .white
-        return view
-    }()
     private let progressView: TestProgressView = .init()
     private let footerView: DailyTestFooterView = .init()
-    private let questionNumberLabel = QuestionNumberLabel(0)
-    private let questionTitleLabel = QuestionTitleLabel("")
-    
+    private let contentsView: DailyTestContentsView = .init()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -39,12 +32,13 @@ extension DailyTestViewController {
         self.view.addSubview(progressView)
         self.view.addSubview(footerView)
         self.view.addSubview(scrollView)
-        scrollView.addSubview(contentView)
+        scrollView.addSubview(contentsView)
         
         progressView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.translatesAutoresizingMaskIntoConstraints = false
-        contentView.translatesAutoresizingMaskIntoConstraints = false
+        contentsView.translatesAutoresizingMaskIntoConstraints = false
         footerView.translatesAutoresizingMaskIntoConstraints = false
+        contentsView.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
             progressView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
@@ -57,15 +51,16 @@ extension DailyTestViewController {
             footerView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
             footerView.heightAnchor.constraint(equalToConstant: 108),
             
-            scrollView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 18),
+            scrollView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -18),
             scrollView.topAnchor.constraint(equalTo: progressView.bottomAnchor),
             scrollView.bottomAnchor.constraint(equalTo: footerView.topAnchor),
             
-            contentView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
-            contentView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
-            contentView.topAnchor.constraint(equalTo: scrollView.topAnchor),
-            contentView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            contentsView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentsView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            contentsView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            contentsView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            contentsView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
         ])
     }
 }

--- a/QRIZ/Feature/DailyTest/ViewController/DailyTestViewController.swift
+++ b/QRIZ/Feature/DailyTest/ViewController/DailyTestViewController.swift
@@ -21,7 +21,7 @@ final class DailyTestViewController: UIViewController {
     }()
     private let progressView: TestProgressView = .init()
     private let footerView: DailyTestFooterView = .init()
-    private let questionNumberLabe = QuestionNumberLabel(0)
+    private let questionNumberLabel = QuestionNumberLabel(0)
     private let questionTitleLabel = QuestionTitleLabel("")
     
 

--- a/QRIZ/Feature/DailyTest/ViewController/DailyTestViewController.swift
+++ b/QRIZ/Feature/DailyTest/ViewController/DailyTestViewController.swift
@@ -41,7 +41,7 @@ final class DailyTestViewController: UIViewController {
     }
     
     private func bind() {
-        let mergedInput = input.merge(with: footerView.input)
+        let mergedInput = input.merge(with: contentsView.input, footerView.input)
         let output = viewModel.transform(input: mergedInput.eraseToAnyPublisher())
         
         output
@@ -58,6 +58,8 @@ final class DailyTestViewController: UIViewController {
                     footerView.updateTotalPage(totalPage: totalPage)
                 case .updateTime(let timeLimit, let timeRemaining):
                     updateProgress(timeLimit: timeLimit, timeRemaining: timeRemaining)
+                case .updateOptionState(let optionIdx, let isSelected):
+                    contentsView.setOptionState(optionIdx: optionIdx, isSelected: isSelected)
                 case .moveToDailyResult:
                     print("Move To Daily Result")
                 case .moveToHomeView:

--- a/QRIZ/Feature/DailyTest/ViewModel/DailyTestViewModel.swift
+++ b/QRIZ/Feature/DailyTest/ViewModel/DailyTestViewModel.swift
@@ -13,20 +13,19 @@ final class DailyTestViewModel {
     // MARK: - Input & Output
     enum Input {
         case viewDidLoad
-//        case viewDidAppear
-//        case previousButtonClicked
-//        case nextButtonClicked
+        case viewDidAppear
+        case nextButtonClicked
         case cancelButtonClicked
 //        case alertSubmitButtonClicked
 //        case alertCancelButtonClicked
     }
     
     enum Output {
-//        case updateQuestion(question: QuestionData)
-//        case updateLastQuestionNum(lastNum: Int)
-//        case updateLastQuestionNum(num: Int)
+        case fetchFailed
+        case updateQuestion(question: QuestionData)
+        case updateTotalPage(totalPage: Int)
         case updateTime(timeLimit: Int, timeRemaining: Int)
-//        case moveToPreviewResult
+        case moveToDailyResult
         case moveToHomeView
 //        case submitSuccess
 //        case submitFail
@@ -34,8 +33,21 @@ final class DailyTestViewModel {
     }
     
     // MARK: - Properties
+    
+    private var questionList: [QuestionData]? = nil
+    private var curNum: Int? = nil
+    private var timer: Timer? = nil
+    private var timeLimit: Int? = nil
+    private var startTime: Date? = nil
+    
     private let output: PassthroughSubject<Output, Never> = .init()
     private var subscriptions = Set<AnyCancellable>()
+    
+    // MARK: - Deinitializer
+    deinit {
+        exitTimer()
+        print("DEINIT: DailyTestViewModel")
+    }
     
     // MARK: - Methods
     func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
@@ -43,18 +55,94 @@ final class DailyTestViewModel {
             guard let self = self else { return }
             switch event {
             case .viewDidLoad:
-                output.send(.updateTime(timeLimit: 10, timeRemaining: 3))
+                fetchData()
+                curNum = 1
+                output.send(.updateTotalPage(totalPage: questionList?.count ?? 0))
+                questionStateHandler()
             case .cancelButtonClicked:
+                exitTimer()
                 output.send(.moveToHomeView)
-//            case .viewDidAppear:
-//            case .previousButtonClicked:
-//            case .nextButtonClicked:
-//            case .escapeButtonClicked:
+            case .viewDidAppear:
+                startTimer()
+            case .nextButtonClicked:
+                guard let currentNumber = curNum, let questionList = questionList else { return }
+                if currentNumber >= questionList.count {
+                    
+                    print("submit alert")
+                } else {
+                    curNum = currentNumber + 1
+                    questionStateHandler()
+                }
 //            case .alertSubmitButtonClicked:
 //            case .alertCancelButtonClicked:
             }
         }
         .store(in: &subscriptions)
         return output.eraseToAnyPublisher()
+    }
+    
+    private func fetchData() {
+        fetchMockData()
+    }
+    
+    private func fetchMockData() {
+        questionList = QuestionData.dailySampleList
+    }
+    
+    private func questionStateHandler() {
+        guard let questionList = questionList, let curNum = curNum else { return }
+        if curNum > questionList.count {
+            exitTimer()
+            output.send(.moveToDailyResult)
+            // submit result here
+            return
+        }
+        output.send(.updateQuestion(question: questionList[curNum - 1]))
+        resetTimer()
+    }
+}
+
+// MARK: - Timer Methods
+extension DailyTestViewModel {
+    private func startTimer() {
+        startTime = Date()
+        timer = Timer.scheduledTimer(timeInterval: 1.0, target: self, selector: #selector(updateTimerPerSecond), userInfo: nil, repeats: true)
+    }
+    
+    @objc func updateTimerPerSecond() {
+        guard let timeLimit = timeLimit, let startTime = startTime else { return }
+        let timeElapsed = Int(Date().timeIntervalSince(startTime))
+        let timeRemaining = timeLimit - timeElapsed
+        if timeRemaining >= 0 {
+            output.send(.updateTime(timeLimit: timeLimit, timeRemaining: timeRemaining))
+            print(timeLimit, timeRemaining)
+        } else {
+            guard let currentNumber = curNum else { return }
+            curNum = currentNumber + 1
+            questionStateHandler()
+        }
+    }
+    
+    private func timerStateHandler() {
+        guard let currentNumber = curNum, let questionList = questionList else { return }
+        if currentNumber < questionList.count {
+            curNum = currentNumber + 1
+            questionStateHandler()
+        } else {
+            exitTimer()
+            // send result
+            output.send(.moveToDailyResult)
+        }
+    }
+    
+    private func resetTimer() {
+        guard let questionList = questionList, let curNum = curNum else { return }
+        startTime = Date()
+        timeLimit = questionList[curNum - 1].timeLimit
+    }
+
+    private func exitTimer() {
+        timer?.invalidate()
+        timer = nil
     }
 }

--- a/QRIZ/Feature/DailyTest/ViewModel/DailyTestViewModel.swift
+++ b/QRIZ/Feature/DailyTest/ViewModel/DailyTestViewModel.swift
@@ -6,7 +6,55 @@
 //
 
 import Foundation
+import Combine
 
 final class DailyTestViewModel {
     
+    // MARK: - Input & Output
+    enum Input {
+        case viewDidLoad
+//        case viewDidAppear
+//        case previousButtonClicked
+//        case nextButtonClicked
+        case cancelButtonClicked
+//        case alertSubmitButtonClicked
+//        case alertCancelButtonClicked
+    }
+    
+    enum Output {
+//        case updateQuestion(question: QuestionData)
+//        case updateLastQuestionNum(lastNum: Int)
+//        case updateLastQuestionNum(num: Int)
+        case updateTime(timeLimit: Int, timeRemaining: Int)
+//        case moveToPreviewResult
+        case moveToHomeView
+//        case submitSuccess
+//        case submitFail
+//        case cancelSubmit
+    }
+    
+    // MARK: - Properties
+    private let output: PassthroughSubject<Output, Never> = .init()
+    private var subscriptions = Set<AnyCancellable>()
+    
+    // MARK: - Methods
+    func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
+        input.sink { [weak self] event in
+            guard let self = self else { return }
+            switch event {
+            case .viewDidLoad:
+                output.send(.updateTime(timeLimit: 10, timeRemaining: 3))
+            case .cancelButtonClicked:
+                output.send(.moveToHomeView)
+//            case .viewDidAppear:
+//            case .previousButtonClicked:
+//            case .nextButtonClicked:
+//            case .escapeButtonClicked:
+//            case .alertSubmitButtonClicked:
+//            case .alertCancelButtonClicked:
+            }
+        }
+        .store(in: &subscriptions)
+        return output.eraseToAnyPublisher()
+    }
 }

--- a/QRIZ/Feature/DailyTest/ViewModel/DailyTestViewModel.swift
+++ b/QRIZ/Feature/DailyTest/ViewModel/DailyTestViewModel.swift
@@ -164,6 +164,9 @@ extension DailyTestViewModel {
     private func startTimer() {
         startTime = Date()
         timer = Timer.scheduledTimer(timeInterval: 1.0, target: self, selector: #selector(updateTimerPerSecond), userInfo: nil, repeats: true)
+        if let timer = timer {
+            RunLoop.main.add(timer, forMode: .common)
+        }
     }
     
     @objc func updateTimerPerSecond() {

--- a/QRIZ/Feature/DailyTest/ViewModel/DailyTestViewModel.swift
+++ b/QRIZ/Feature/DailyTest/ViewModel/DailyTestViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  DailyTestViewModel.swift
+//  QRIZ
+//
+//  Created by 이창현 on 4/1/25.
+//
+
+import Foundation
+
+final class DailyTestViewModel {
+    
+}

--- a/QRIZ/Feature/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
+++ b/QRIZ/Feature/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
@@ -217,9 +217,7 @@ extension PreviewTestViewController {
     }
     
     private func formattedTime(timeRemaining: Int) -> String {
-        let minutes = timeRemaining / 60
-        let seconds = timeRemaining % 60
-        return String(format: "%02d:%02d", minutes, seconds)
+        return timeRemaining.formattedTime
     }
 }
 

--- a/QRIZ/Feature/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
+++ b/QRIZ/Feature/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
@@ -15,8 +15,8 @@ final class PreviewTestViewController: UIViewController {
     private var lastQuestionNum: Int = 0
     private var curNum: Int = 0
     
-    private let questionNumberLabel = QuestionNumberLabel(0)
-    private let questionTitleLabel = QuestionTitleLabel("")
+    private let questionNumberLabel = QuestionNumberLabel()
+    private let questionTitleLabel = QuestionTitleLabel()
     private let optionLabels: [QuestionOptionLabel] = {
         var arr: [QuestionOptionLabel] = []
         for i in 1...4 {

--- a/QRIZ/Feature/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
+++ b/QRIZ/Feature/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
@@ -144,7 +144,8 @@ final class PreviewTestViewController: UIViewController {
         questionTitleLabel.setTitle(question.question)
         setSelectedOption(question.selectedOption)
         setOptionsString(optStringArr)
-        pageIndicatorLabel.setPages(curPage: question.questionNumber, totalPage: lastQuestionNum)
+        pageIndicatorLabel.setCurPage(curPage: question.questionNumber)
+        pageIndicatorLabel.setTotalPage(totalPage: lastQuestionNum)
         setPageButtonsUI(question.questionNumber)
     }
 }

--- a/QRIZ/Feature/Onboarding/PreviewTest/ViewModel/PreviewTestViewModel.swift
+++ b/QRIZ/Feature/Onboarding/PreviewTest/ViewModel/PreviewTestViewModel.swift
@@ -36,7 +36,7 @@ final class PreviewTestViewModel {
     }
     
     // MARK: - Properties
-    private var questionList = QuestionData.sampleList
+    private var questionList = QuestionData.previewSampleList
     private var currentNumber: Int? = nil
     private var totalTimeLimit: Int? = 1500 // tmp
     private var timer: Timer? = nil

--- a/QRIZ/Feature/Onboarding/PreviewTest/ViewModel/PreviewTestViewModel.swift
+++ b/QRIZ/Feature/Onboarding/PreviewTest/ViewModel/PreviewTestViewModel.swift
@@ -118,6 +118,9 @@ extension PreviewTestViewModel {
     private func startTimer() {
         startTime = Date()
         timer = Timer.scheduledTimer(timeInterval: 1.0, target: self, selector: #selector(updateTimer), userInfo: nil, repeats: true)
+        if let timer = timer {
+            RunLoop.main.add(timer, forMode: .common)
+        }
     }
     
     @objc func updateTimer() {

--- a/QRIZ/Feature/TestComponents/QuestionNumberLabel.swift
+++ b/QRIZ/Feature/TestComponents/QuestionNumberLabel.swift
@@ -10,9 +10,9 @@ import UIKit
 final class QuestionNumberLabel: UILabel {
     
     // MARK: - Initializers
-    init(_ questionNumber: Int) {
+    init() {
         super.init(frame: .zero)
-        setNumber(questionNumber)
+        setNumber(1)
         self.textColor = .black
         self.font = .boldSystemFont(ofSize: 20)
     }

--- a/QRIZ/Feature/TestComponents/QuestionOptionLabel.swift
+++ b/QRIZ/Feature/TestComponents/QuestionOptionLabel.swift
@@ -10,14 +10,32 @@ import UIKit
 final class QuestionOptionLabel: UILabel {
 
     // MARK: - Properties
-    private var optionNumberLabel: UILabel!
-    private var optionStringLabel: UILabel!
+    private var optionNumberLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.font = .boldSystemFont(ofSize: 16)
+        label.numberOfLines = 1
+
+        label.layer.masksToBounds = true
+        label.layer.cornerRadius = 20
+        label.layer.borderColor = UIColor.coolNeutral700.cgColor
+        label.layer.borderWidth = 1.25
+        
+        return label
+    }()
+    private var optionStringLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .left
+        label.textColor = .coolNeutral700
+        label.font = .systemFont(ofSize: 16, weight: .regular)
+        label.numberOfLines = 0
+        return label
+    }()
     
     // MARK: - Initializers
     init(optNum: Int) {
         super.init(frame: .zero)
-        createNumberLabel(optNum)
-        createStringLabel()
+        optionNumberLabel.text = "\(optNum)"
         setOptionState(isSelected: false)
         addViews()
     }
@@ -27,8 +45,10 @@ final class QuestionOptionLabel: UILabel {
     }
     
     // MARK: - Methods
-    func setOptionString(_ str: String) {
+    func setOptionString(_ str: String, isSqlOrFunc: Bool = false) {
         optionStringLabel.attributedText = formattedText(str)
+        optionStringLabel.font = isSqlOrFunc ? .systemFont(ofSize: 14, weight: .regular) : .systemFont(ofSize: 16, weight: .regular)
+        moveOptionStringLabel(isSqlorFunc: isSqlOrFunc) // 
     }
     
     func setOptionState(isSelected: Bool) {
@@ -99,5 +119,9 @@ extension QuestionOptionLabel {
             optionStringLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: 16),
             optionStringLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -16)
         ])
+    }
+    
+    private func moveOptionStringLabel(isSqlorFunc: Bool) {
+        //
     }
 }

--- a/QRIZ/Feature/TestComponents/QuestionTitleLabel.swift
+++ b/QRIZ/Feature/TestComponents/QuestionTitleLabel.swift
@@ -16,7 +16,7 @@ final class QuestionTitleLabel: UILabel {
         self.textAlignment = .left
         self.numberOfLines = 0
         self.textColor = .black
-        self.font = .boldSystemFont(ofSize: 16)
+        self.font = .systemFont(ofSize: 16, weight: .medium)
     }
     
     required init?(coder: NSCoder) {
@@ -24,13 +24,17 @@ final class QuestionTitleLabel: UILabel {
     }
     
     // MARK: - Methods
-    func setTitle(_ titleStr: String) {
+    func setTitle(_ text: String) {
+        self.attributedText = formattedText(text)
+    }
+    
+    private func formattedText(_ text: String) -> NSMutableAttributedString {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = 4
-
-        let attributedtext = NSMutableAttributedString(string: titleStr)
+        
+        let attributedtext = NSMutableAttributedString(string: text)
         attributedtext.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: attributedtext.length))
-
-        self.attributedText = attributedtext
+        
+        return attributedtext
     }
 }

--- a/QRIZ/Feature/TestComponents/QuestionTitleLabel.swift
+++ b/QRIZ/Feature/TestComponents/QuestionTitleLabel.swift
@@ -10,9 +10,9 @@ import UIKit
 final class QuestionTitleLabel: UILabel {
     
     // MARK: - Initializers
-    init(_ titleStr: String) {
+    init() {
         super.init(frame: .zero)
-        self.text = titleStr
+        self.text = " "
         self.textAlignment = .left
         self.numberOfLines = 0
         self.textColor = .black
@@ -25,6 +25,12 @@ final class QuestionTitleLabel: UILabel {
     
     // MARK: - Methods
     func setTitle(_ titleStr: String) {
-        self.text = titleStr
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 4
+
+        let attributedtext = NSMutableAttributedString(string: titleStr)
+        attributedtext.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: attributedtext.length))
+
+        self.attributedText = attributedtext
     }
 }

--- a/QRIZ/Feature/TestComponents/TestPageIndicatorLabel.swift
+++ b/QRIZ/Feature/TestComponents/TestPageIndicatorLabel.swift
@@ -42,18 +42,8 @@ final class TestPageIndicatorLabel: UILabel {
 
     // MARK: - Methods
     func setPages(curPage: Int, totalPage: Int) {
-        var curPg = "\(curPage) "
-        var totalPg = "/ \(totalPage)"
-        
-        if curPage < 10 {
-            curPg = "0" + curPg
-        }
-        if totalPage < 10 {
-            totalPg = "0" + totalPg
-        }
-
-        self.currentPageLabel.text = curPg
-        self.totalPageLabel.text = totalPg
+        self.currentPageLabel.text = String(format: "%02d ", curPage)
+        self.totalPageLabel.text = String(format: "/ %02d", totalPage)
     }
 }
 

--- a/QRIZ/Feature/TestComponents/TestPageIndicatorLabel.swift
+++ b/QRIZ/Feature/TestComponents/TestPageIndicatorLabel.swift
@@ -42,8 +42,18 @@ final class TestPageIndicatorLabel: UILabel {
 
     // MARK: - Methods
     func setPages(curPage: Int, totalPage: Int) {
-        self.currentPageLabel.text = "\(curPage) "
-        self.totalPageLabel.text = "/ \(totalPage)"
+        var curPg = "\(curPage) "
+        var totalPg = "/ \(totalPage)"
+        
+        if curPage < 10 {
+            curPg = "0" + curPg
+        }
+        if totalPage < 10 {
+            totalPg = "0" + totalPg
+        }
+
+        self.currentPageLabel.text = curPg
+        self.totalPageLabel.text = totalPg
     }
 }
 

--- a/QRIZ/Feature/TestComponents/TestPageIndicatorLabel.swift
+++ b/QRIZ/Feature/TestComponents/TestPageIndicatorLabel.swift
@@ -12,7 +12,7 @@ final class TestPageIndicatorLabel: UILabel {
     // MARK: - Properties
     private var currentPageLabel: UILabel = {
         let label = UILabel()
-        label.text = "0"
+        label.text = String(format: "%02d ", 0)
         label.font = .boldSystemFont(ofSize: 16)
         label.textAlignment = .right
         label.numberOfLines = 1
@@ -22,7 +22,7 @@ final class TestPageIndicatorLabel: UILabel {
     
     private var totalPageLabel: UILabel = {
         let label = UILabel()
-        label.text = "/0"
+        label.text = String(format: "/ %02d", 0)
         label.font = .systemFont(ofSize: 16)
         label.textAlignment = .left
         label.numberOfLines = 1

--- a/QRIZ/Feature/TestComponents/TestPageIndicatorLabel.swift
+++ b/QRIZ/Feature/TestComponents/TestPageIndicatorLabel.swift
@@ -41,8 +41,11 @@ final class TestPageIndicatorLabel: UILabel {
     }
 
     // MARK: - Methods
-    func setPages(curPage: Int, totalPage: Int) {
+    func setCurPage(curPage: Int) {
         self.currentPageLabel.text = String(format: "%02d ", curPage)
+    }
+    
+    func setTotalPage(totalPage: Int) {
         self.totalPageLabel.text = String(format: "/ %02d", totalPage)
     }
 }

--- a/QRIZ/Utils/Extensions/Int+.swift
+++ b/QRIZ/Utils/Extensions/Int+.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-
 extension Int {
     // 테스트 화면에서 타이머에 시간을 제공하기 위한 extension 입니다.
     var formattedTime: String {

--- a/QRIZ/Utils/Extensions/Int+.swift
+++ b/QRIZ/Utils/Extensions/Int+.swift
@@ -1,0 +1,18 @@
+//
+//  Int+.swift
+//  QRIZ
+//
+//  Created by ch on 4/16/25.
+//
+
+import Foundation
+
+
+extension Int {
+    // 테스트 화면에서 타이머에 시간을 제공하기 위한 extension 입니다.
+    var formattedTime: String {
+        let minutes = self / 60
+        let seconds = self % 60
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+}

--- a/QRIZ/Utils/Model/TestModel/QuestionData.swift
+++ b/QRIZ/Utils/Model/TestModel/QuestionData.swift
@@ -35,7 +35,7 @@ struct QuestionData {
         }
     }
     
-    static var sampleList: [QuestionData] = {
+    static var previewSampleList: [QuestionData] = {
         var list: [QuestionData] = []
         for i in 0..<20 {
             var question: QuestionData
@@ -45,6 +45,73 @@ struct QuestionData {
                 question = QuestionData(question: "다음 중 트랜잭션 모델링에서 '긴 트랜잭션(Long Transaction)'을 처리하는 방법으로 가장 적절한 것은?", option1: "트랜잭션을 더 작은 단위로 분할", option2: "트랜잭션의 타임아웃 시간을 늘림", option3: "모든 데이터를 메모리에 로드", option4: "트랜잭션의 격리 수준을 낮춤", timeLimit: 70, questionNumber: i + 1)
             } else {
                 question = QuestionData(question: "다음 중 트랜잭션 모델링에서 '긴 트랜잭션(Long Transaction)'을 처리하는 방법으로 가장 적절한 것은?다음 중 트랜잭션 모델링에서 '긴 트랜잭션(Long Transaction)'을 처리하는 방법으로 가장 적절한 것은?다음 중 트랜잭션 모델링에서 '긴 트랜잭션(Long Transaction)'을 처리하는 방법으로 가장 적절한 것은?", option1: "트랜잭션을 더 작은 단위로 분할", option2: "트랜잭션의 타임아웃 시간을 늘림", option3: "모든 데이터를 메모리에 로드", option4: "트랜잭션의 격리 수준을 낮춤", timeLimit: 70, questionNumber: i + 1)
+            }
+            list.append(question)
+        }
+        return list
+    }()
+    
+    static var dailySampleList: [QuestionData] = {
+        var list: [QuestionData] = []
+        for i in 0..<6 {
+            var question: QuestionData
+            if i % 2 == 0 {
+                question = QuestionData(question: "다음과 같은 상황에서 적절한 엔터티 도출 방식은?",
+                                        option1: """
+                                        기본 엔터티: 고객, 상품
+                                        중심 엔터티: 주문
+                                        행위 엔터티: 주문상품
+                                        코드 엔터티: 주문상태
+                                        """,
+                                        option2: """
+                                        기본 엔터티: 고객, 상품
+                                        중심 엔터티: 주문
+                                        행위 엔터티: 주문상품
+                                        코드 엔터티: 주문상태
+                                        """,
+                                        option3: """
+                                        기본 엔터티: 고객, 상품
+                                        중심 엔터티: 주문
+                                        행위 엔터티: 주문상품
+                                        코드 엔터티: 주문상태
+                                        """,
+                                        option4: """
+                                        기본 엔터티: 고객, 상품
+                                        중심 엔터티: 주문
+                                        행위 엔터티: 주문상품
+                                        코드 엔터티: 주문상태
+                                        """,
+                                        timeLimit: 300,
+                                        questionNumber: i + 1,
+                                        description: """
+                                            [업무상황]
+                                            1. 고객이 상품을 주문한다.
+                                            2. 한 번의 주문에 여러 상품을 담을 수 있다.
+                                            3. 상품의 재고는 실시간으로 관리되어야 한다.
+                                            4. 주문 상태는 '주문', '결제', '배송', '완료'로 관리된다.
+                                        """,
+                                        skillId: 2)
+                
+            } else {
+                question = QuestionData(question: "다음과 같은 데이터에서 필요한 분석을 위한 적절한 윈도우 함수 사용은?",
+                                        option1: """
+                                            ```sql SELECT p2.PROD_ID, p2.PROD_NAME FROM PRODUCTS p2 WHERE p2.CATEGORY = (     SELECT p1.CATEGORY     FROM PURCHASES pu     JOIN PRODUCTS p1 ON pu.PROD_ID = p1.PROD_ID     WHERE pu.ORDER_DATE = (         SELECT MAX(ORDER_DATE)         FROM PURCHASES     ) ) AND p2.PROD_ID NOT IN (     SELECT PROD_ID     FROM PURCHASES ); ```
+                                            """,
+                                        option2: """
+                                            ```sql SELECT p2.PROD_ID, p2.PROD_NAME FROM PRODUCTS p2 WHERE p2.CATEGORY = (     SELECT p1.CATEGORY     FROM PURCHASES pu     JOIN PRODUCTS p1 ON pu.PROD_ID = p1.PROD_ID     WHERE pu.ORDER_DATE = (         SELECT MAX(ORDER_DATE)         FROM PURCHASES     ) ) AND p2.PROD_ID NOT IN (     SELECT PROD_ID     FROM PURCHASES ); ```
+                                            """,
+                                        option3: """
+                                            ```sql SELECT p2.PROD_ID, p2.PROD_NAME FROM PRODUCTS p2 WHERE p2.CATEGORY = (     SELECT p1.CATEGORY     FROM PURCHASES pu     JOIN PRODUCTS p1 ON pu.PROD_ID = p1.PROD_ID     WHERE pu.ORDER_DATE = (         SELECT MAX(ORDER_DATE)         FROM PURCHASES     ) ) AND p2.PROD_ID NOT IN (     SELECT PROD_ID     FROM PURCHASES ); ```
+                                            """,
+                                        option4: """
+                                            ```sql SELECT p2.PROD_ID, p2.PROD_NAME FROM PRODUCTS p2 WHERE p2.CATEGORY = (     SELECT p1.CATEGORY     FROM PURCHASES pu     JOIN PRODUCTS p1 ON pu.PROD_ID = p1.PROD_ID     WHERE pu.ORDER_DATE = (         SELECT MAX(ORDER_DATE)         FROM PURCHASES     ) ) AND p2.PROD_ID NOT IN (     SELECT PROD_ID     FROM PURCHASES ); ```
+                                            """,
+                                        timeLimit: 300,
+                                        questionNumber: i + 1,
+                                        description: """
+                                            ```sql [매출데이터] SALES_DATE    AMOUNT 2024-01-01    1000 2024-01-02    1200 2024-01-03    800 2024-01-04    1500 ...  [요구사항] 1. 일자별 매출 금액 2. 전일 대비 증감액 3. 3일 이동평균 4. 연초부터의 누적 매출 ```
+                                            """,
+                                        skillId: 13)
             }
             list.append(question)
         }


### PR DESCRIPTION
## 🛠️ Task

- 데일리 테스트 뷰 구현

## 🌱 PR Point

- 데일리 테스트 뷰 및 뷰모델을 구현했습니다.
- 페이지 표시를 하는 pageIndicatorLabel, 다음 버튼을 나타내는 nextButton을 따로 묶어서 footerView로써 처리했습니다. (이전버튼은 존재 X)
- contentsView를 스크롤뷰로 존재하도록 했습니다.
- 스크롤 시 타이머가 동작하는 이벤트 발생 => RunLoop의 모드로 인한 지연 현상으로, Timer를 RunLoop.main에 .common 모드로 등록했습니다.
- 프리뷰 테스트의 뷰모델에서 역시 타이머를 동일한 방식으로 적용했습니다.
- 임시로 QuestionData 모델 내부에 프리뷰 테스트 때와 마찬가지로 static 으로 샘플 배열을 삽입해서 가져오도록 구현했습니다.
- 임시로 데일리 테스트 결과 뷰를 넣었습니다. 추후에 데일리 테스트 결과 뷰 구현하겠습니다.

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 데일리 테스트 뷰 | ![image](https://github.com/user-attachments/assets/da299332-c9e5-40c8-b12e-a55ec8275e7b) |

## 📮 Issue 번호
- resolved: #42 
