### PR TITLE
FEAT: 온보딩 코디네이터 구현

### DIFF
--- a/Network/Service/Daily/DailyService.swift
+++ b/Network/Service/Daily/DailyService.swift
@@ -58,8 +58,7 @@ final class DailyServiceImpl: DailyService {
     }
     
     private func getAccessToken() -> String {
-        let accessToken = keychainManager.retrieveToken(forKey: "accessToken") ?? ""
-        if accessToken.isEmpty { print("DailyService failed to get accessToken") }
+        let accessToken = keychainManager.retrieveToken(forKey: HTTPHeaderField.accessToken.rawValue) ?? ""
         return accessToken
     }
 }

--- a/Network/Service/Exam/ExamService.swift
+++ b/Network/Service/Exam/ExamService.swift
@@ -58,8 +58,7 @@ final class ExamServiceImpl: ExamService {
     }
     
     private func getAccessToken() -> String {
-        let accessToken = keychainManager.retrieveToken(forKey: "accessToken") ?? ""
-        if accessToken.isEmpty { print("ExamService failed to get accessToken") }
+        let accessToken = keychainManager.retrieveToken(forKey: HTTPHeaderField.accessToken.rawValue) ?? ""
         return accessToken
     }
 }

--- a/Network/Service/Onboarding/OnboardingService.swift
+++ b/Network/Service/Onboarding/OnboardingService.swift
@@ -53,8 +53,7 @@ final class OnboardingServiceImpl: OnboardingService {
     
     // reissue로 인한 키체인의 accessToken이 변경되는 경우를 대비해서 매번 가져옴
     private func getAccessToken() -> String {
-        let accessToken = keychainManager.retrieveToken(forKey: "accessToken") ?? ""
-        if accessToken.isEmpty { print("OnboardingService failed to get accessToken") }
+        let accessToken = keychainManager.retrieveToken(forKey: HTTPHeaderField.accessToken.rawValue) ?? ""
         return accessToken
     }
 }

--- a/Network/Service/UserInfo/UserInfoService.swift
+++ b/Network/Service/UserInfo/UserInfoService.swift
@@ -28,7 +28,6 @@ final class UserInfoServiceImpl: UserInfoService {
     
     private func getAccessToken() -> String {
         let accessToken = keychainManager.retrieveToken(forKey: HTTPHeaderField.accessToken.rawValue) ?? ""
-        if accessToken.isEmpty { print("OnboardingService failed to get accessToken") }
         return accessToken
     }
 }

--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 		E2A6C6762DCA45970059F960 /* ExamResultRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A6C6752DCA45970059F960 /* ExamResultRequest.swift */; };
 		E2A6C7352DCA4C850059F960 /* ExamService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A6C7342DCA4C850059F960 /* ExamService.swift */; };
 		E2C084BE2D89AF2C0096CE20 /* PreviewResultInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C084BD2D89AF2C0096CE20 /* PreviewResultInfoView.swift */; };
+		E2C1016B2DF2E10200C3512E /* OnboardingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C1016A2DF2E10200C3512E /* OnboardingCoordinator.swift */; };
 		E2D70FE82D0DD322005A3F51 /* BeginPreviewTestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D70FE72D0DD322005A3F51 /* BeginPreviewTestViewModel.swift */; };
 		E2D70FEC2D0EBDDD005A3F51 /* CheckListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D70FEB2D0EBDDD005A3F51 /* CheckListCell.swift */; };
 		E2D70FEE2D0EC037005A3F51 /* CheckConceptViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D70FED2D0EC037005A3F51 /* CheckConceptViewModel.swift */; };
@@ -479,6 +480,7 @@
 		E2A6C6752DCA45970059F960 /* ExamResultRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamResultRequest.swift; sourceTree = "<group>"; };
 		E2A6C7342DCA4C850059F960 /* ExamService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamService.swift; sourceTree = "<group>"; };
 		E2C084BD2D89AF2C0096CE20 /* PreviewResultInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewResultInfoView.swift; sourceTree = "<group>"; };
+		E2C1016A2DF2E10200C3512E /* OnboardingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCoordinator.swift; sourceTree = "<group>"; };
 		E2D70FE72D0DD322005A3F51 /* BeginPreviewTestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeginPreviewTestViewModel.swift; sourceTree = "<group>"; };
 		E2D70FEB2D0EBDDD005A3F51 /* CheckListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckListCell.swift; sourceTree = "<group>"; };
 		E2D70FED2D0EC037005A3F51 /* CheckConceptViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckConceptViewModel.swift; sourceTree = "<group>"; };
@@ -1149,6 +1151,7 @@
 				E29CCD182D2982AD004AA30A /* PreviewTest */,
 				E29CCD3B2D298656004AA30A /* PreviewResult */,
 				E29CCD482D29867F004AA30A /* Greeting */,
+				E2C1016A2DF2E10200C3512E /* OnboardingCoordinator.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -2022,7 +2025,6 @@
 				B16288262D300CBA008057D0 /* PasswordInputViewModel.swift in Sources */,
 				E2908E682DB3A68E00B8E81B /* ResultDetailView.swift in Sources */,
 				B1D813712D6E0C1F00A9D447 /* HomeCoordinator.swift in Sources */,
-				E2019A242DE9E1F5008AD668 /* Date+.swift in Sources */,
 				E23824E12D0C3157009E7989 /* BeginOnboardingViewController.swift in Sources */,
 				B16774D72D89D2EE001820F3 /* AccountRecoveryService.swift in Sources */,
 				E29CCD292D29855B004AA30A /* QuestionNumberLabel.swift in Sources */,
@@ -2081,7 +2083,6 @@
 				B18F450D2D3994380030F7DB /* FindIDMainView.swift in Sources */,
 				B168B7692D2807470000F32E /* SignUpVerificationViewController.swift in Sources */,
 				54E91B762D18FACD00474D0A /* RoundButton.swift in Sources */,
-				54DB0D992D0950DE00ABD458 /* HomeViewModel.swift in Sources */,
 				E24991B32DE599B70012BA13 /* ScoreGraphFilterType.swift in Sources */,
 				E217C3622D9BEA8D0095A3D8 /* DailyTestViewController.swift in Sources */,
 				B17FE30A2D27F8E9002EC7D7 /* UITextField+.swift in Sources */,
@@ -2125,6 +2126,7 @@
 				E25856DE2D0DADD300355667 /* BeginOnboardingViewModel.swift in Sources */,
 				E27843212DDE13B600E9AD07 /* ExamTestViewController.swift in Sources */,
 				B1D9A0E72D3686BA00E84934 /* CountdownTimer.swift in Sources */,
+				E2C1016B2DF2E10200C3512E /* OnboardingCoordinator.swift in Sources */,
 				B18F45102D3997280030F7DB /* FindAccountHeaderView.swift in Sources */,
 				E29BF8552D117CF1006DC6D0 /* SurveyCheckList.swift in Sources */,
 				E2DD0E862D2146D900DA3D18 /* IncorrectCountData.swift in Sources */,

--- a/QRIZ/Coordinator/AppCoordinator.swift
+++ b/QRIZ/Coordinator/AppCoordinator.swift
@@ -160,3 +160,19 @@ extension AppCoordinatorImpl: LoginCoordinatorDelegate {
         _ = showTabBar()
     }
 }
+
+// MARK: - OnboardingCoordinatorDelegate
+
+extension AppCoordinatorImpl: OnboardingCoordinatorDelegate {
+    func didFinishOnboarding(_ coordinator: any OnboardingCoordinator) {
+        let service = dependency.userInfoService
+        
+        Task {
+            let response = try await service.getUserInfo()
+            UserInfoManager.shared.update(from: response.data)
+        }
+        
+        childCoordinators.removeAll() { $0 === coordinator }
+        _ = showTabBar()
+    }
+}

--- a/QRIZ/Coordinator/AppCoordinator.swift
+++ b/QRIZ/Coordinator/AppCoordinator.swift
@@ -73,7 +73,9 @@ final class AppCoordinatorDependencyImpl: AppCoordinatorDependency {
     
     var onboardingCoordinator: OnboardingCoordinator {
         let navi = UINavigationController()
-        return OnboardingCoordinatorImpl(navigationController: navi, onboardingService: onboardingService)
+        return OnboardingCoordinatorImpl(navigationController: navi,
+                                         onboardingService: onboardingService,
+                                         userInfoService: userInfoService)
     }
 }
 
@@ -167,13 +169,7 @@ extension AppCoordinatorImpl: SplashCoordinatorDelegate {
     func didFinishSplash(_ coordinator: SplashCoordinator, isLoggedIn: Bool) {
         childCoordinators.removeAll { $0 === coordinator }
         splashCoordinator = nil
-        
-        if isLoggedIn {
-            _ = UserInfoManager.shared.previewTestStatus == .notStarted ?
-            showOnboarding() : showTabBar()
-        } else {
-            _ = showLogin()
-        }
+        _ = isLoggedIn ? showTabBar() : showLogin()
     }
 }
 
@@ -182,7 +178,8 @@ extension AppCoordinatorImpl: SplashCoordinatorDelegate {
 extension AppCoordinatorImpl: LoginCoordinatorDelegate {
     func didLogin(_ coordinator: LoginCoordinator) {
         childCoordinators.removeAll { $0 === coordinator }
-        _ = showSplash()
+        _ = UserInfoManager.shared.previewTestStatus == .notStarted ?
+        showOnboarding() : showTabBar()
     }
 }
 
@@ -191,6 +188,6 @@ extension AppCoordinatorImpl: LoginCoordinatorDelegate {
 extension AppCoordinatorImpl: OnboardingCoordinatorDelegate {
     func didFinishOnboarding(_ coordinator: any OnboardingCoordinator) {
         childCoordinators.removeAll() { $0 === coordinator }
-        _ = showSplash()
+        _ = showTabBar()
     }
 }

--- a/QRIZ/Feature/Onboarding/BeginOnboarding/ViewController/BeginOnboardingViewController.swift
+++ b/QRIZ/Feature/Onboarding/BeginOnboarding/ViewController/BeginOnboardingViewController.swift
@@ -23,7 +23,7 @@ final class BeginOnboardingViewController: UIViewController {
     weak var coordinator: OnboardingCoordinator?
     
     // MARK: - Initializers
-    init(viewModel: BeginOnboardingViewModel = BeginOnboardingViewModel()) {
+    init(viewModel: BeginOnboardingViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }

--- a/QRIZ/Feature/Onboarding/BeginOnboarding/ViewController/BeginOnboardingViewController.swift
+++ b/QRIZ/Feature/Onboarding/BeginOnboarding/ViewController/BeginOnboardingViewController.swift
@@ -39,6 +39,7 @@ final class BeginOnboardingViewController: UIViewController {
         bind()
         addViews()
         addButtonAction()
+        navigationController?.navigationBar.isHidden = true
     }
     
     private func bind() {

--- a/QRIZ/Feature/Onboarding/BeginOnboarding/ViewController/BeginOnboardingViewController.swift
+++ b/QRIZ/Feature/Onboarding/BeginOnboarding/ViewController/BeginOnboardingViewController.swift
@@ -16,9 +16,21 @@ final class BeginOnboardingViewController: UIViewController {
     private let beginOnboardingImageView: UIImageView = UIImageView(image: UIImage(named: "onboarding1"))
     private let beginOnboardingStartButton: UIButton = OnboardingButton("시작하기")
     
-    private var viewModel: BeginOnboardingViewModel = BeginOnboardingViewModel()
+    private var viewModel: BeginOnboardingViewModel
     private let input: PassthroughSubject<BeginOnboardingViewModel.Input, Never> = .init()
     private var subscriptions = Set<AnyCancellable>()
+    
+    weak var coordinator: OnboardingCoordinator?
+    
+    // MARK: - Initializers
+    init(viewModel: BeginOnboardingViewModel = BeginOnboardingViewModel()) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
     
     // MARK: - Methods
     override func viewDidLoad() {
@@ -38,8 +50,7 @@ final class BeginOnboardingViewController: UIViewController {
                 guard let self = self else { return }
                 switch event {
                 case .moveToCheckConcept:
-                    // should modify to using coordinator
-                    self.navigationController?.pushViewController(CheckConceptViewController(), animated: true)
+                    self.coordinator?.showCheckConcept()
                 }
             }
             .store(in: &subscriptions)

--- a/QRIZ/Feature/Onboarding/BeginPreviewTest/ViewController/BeginPreviewTestViewController.swift
+++ b/QRIZ/Feature/Onboarding/BeginPreviewTest/ViewController/BeginPreviewTestViewController.swift
@@ -23,7 +23,7 @@ final class BeginPreviewTestViewController: UIViewController {
     weak var coordinator: OnboardingCoordinator?
     
     // MARK - Initializers
-    init(viewModel: BeginPreviewTestViewModel = BeginPreviewTestViewModel()) {
+    init(viewModel: BeginPreviewTestViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }

--- a/QRIZ/Feature/Onboarding/BeginPreviewTest/ViewController/BeginPreviewTestViewController.swift
+++ b/QRIZ/Feature/Onboarding/BeginPreviewTest/ViewController/BeginPreviewTestViewController.swift
@@ -16,9 +16,21 @@ final class BeginPreviewTestViewController: UIViewController {
     let beginImageView: UIImageView = UIImageView(image: UIImage(named: "onboarding2"))
     let beginTestButton: UIButton = OnboardingButton("간단한 테스트 시작")
     
-    private var viewModel: BeginPreviewTestViewModel = BeginPreviewTestViewModel()
+    private var viewModel: BeginPreviewTestViewModel
     private let input: PassthroughSubject<BeginPreviewTestViewModel.Input, Never> = .init()
     private var subscriptions = Set<AnyCancellable>()
+    
+    weak var coordinator: OnboardingCoordinator?
+    
+    // MARK - Initializers
+    init(viewModel: BeginPreviewTestViewModel = BeginPreviewTestViewModel()) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
     
     // MARK: - Methods
     override func viewDidLoad() {
@@ -39,8 +51,7 @@ final class BeginPreviewTestViewController: UIViewController {
                 guard let self = self else { return }
                 switch event {
                 case .moveToPreviewTest:
-                    self.navigationController?.pushViewController(PreviewTestViewController(), animated: true)
-                    // coordinator
+                    self.coordinator?.showPreviewTest()
                 }
             }
             .store(in: &subscriptions)

--- a/QRIZ/Feature/Onboarding/BeginPreviewTest/ViewController/BeginPreviewTestViewController.swift
+++ b/QRIZ/Feature/Onboarding/BeginPreviewTest/ViewController/BeginPreviewTestViewController.swift
@@ -36,7 +36,6 @@ final class BeginPreviewTestViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = .white
-        self.navigationItem.hidesBackButton = true
         bind()
         addViews()
         addButtonAction()

--- a/QRIZ/Feature/Onboarding/CheckConcept/ViewController/CheckConceptViewController.swift
+++ b/QRIZ/Feature/Onboarding/CheckConcept/ViewController/CheckConceptViewController.swift
@@ -28,9 +28,21 @@ final class CheckConceptViewController: UIViewController {
     }()
     private let checkDoneButton = OnboardingButton("선택완료")
     
-    private let viewModel: CheckConceptViewModel = CheckConceptViewModel(onboardingService: OnboardingServiceImpl())
+    private let viewModel: CheckConceptViewModel
     private let input: PassthroughSubject<CheckConceptViewModel.Input, Never> = .init()
     private var subscriptions = Set<AnyCancellable>()
+    
+    weak var coordinator: OnboardingCoordinator?
+    
+    // MARK: - Initializers
+    init(viewModel: CheckConceptViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
     
     // MARK: - Methods
     override func viewDidLoad() {
@@ -58,9 +70,9 @@ final class CheckConceptViewController: UIViewController {
                 guard let self = self else { return }
                 switch event {
                 case .moveToBeginPreviewTest:
-                    self.navigationController?.pushViewController(BeginPreviewTestViewController(), animated: true)
+                    self.coordinator?.showBeginPreviewTest()
                 case .moveToGreeting:
-                    self.navigationController?.pushViewController(GreetingViewController(), animated: true)
+                    self.coordinator?.showGreeting()
                 case .setAllAndNone(let numOfSelectedConcept, let checkNoneClicked):
                     checkNoneButton.checkboxHandler(numOfSelectedConcept: numOfSelectedConcept, checkNoneClicked: checkNoneClicked)
                     checkAllButton.checkboxHandler(numOfSelectedConcept: numOfSelectedConcept)

--- a/QRIZ/Feature/Onboarding/CheckConcept/ViewController/CheckConceptViewController.swift
+++ b/QRIZ/Feature/Onboarding/CheckConcept/ViewController/CheckConceptViewController.swift
@@ -51,7 +51,6 @@ final class CheckConceptViewController: UIViewController {
         setCollectionView()
         bind()
         addViews()
-        navigationController?.navigationBar.isHidden = true
         addButtonAction()
     }
     

--- a/QRIZ/Feature/Onboarding/Greeting/ViewController/GreetingViewController.swift
+++ b/QRIZ/Feature/Onboarding/Greeting/ViewController/GreetingViewController.swift
@@ -23,7 +23,7 @@ final class GreetingViewController: UIViewController {
     weak var coordinator: OnboardingCoordinator?
     
     // MARK: - Initializers
-    init(viewModel: GreetingViewModel = GreetingViewModel()) {
+    init(viewModel: GreetingViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }

--- a/QRIZ/Feature/Onboarding/Greeting/ViewController/GreetingViewController.swift
+++ b/QRIZ/Feature/Onboarding/Greeting/ViewController/GreetingViewController.swift
@@ -16,9 +16,21 @@ final class GreetingViewController: UIViewController {
     private let greetingSubtitleLabel: UILabel = OnboardingSubtitleLabel("준비되어 있는 오늘의 공부와, 모의고사로\n시험을 같이 준비해봐요!")
     private let greetingImageView: UIImageView = UIImageView(image: UIImage(named: "onboarding3"))
     
-    private var viewModel: GreetingViewModel = GreetingViewModel()
+    private var viewModel: GreetingViewModel
     private var subscriptions = Set<AnyCancellable>()
     private let input: PassthroughSubject<GreetingViewModel.Input, Never> = .init()
+    
+    weak var coordinator: OnboardingCoordinator?
+    
+    // MARK: - Initializers
+    init(viewModel: GreetingViewModel = GreetingViewModel()) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
     
     // MARK: - Methods
     override func viewDidLoad() {
@@ -44,7 +56,7 @@ final class GreetingViewController: UIViewController {
                 guard let self = self else { return }
                 switch event {
                 case .moveToHome:
-                    // coordinator role
+                    // coordinator delegate
                     self.dismiss(animated: true)
                 }
             }

--- a/QRIZ/Feature/Onboarding/Greeting/ViewController/GreetingViewController.swift
+++ b/QRIZ/Feature/Onboarding/Greeting/ViewController/GreetingViewController.swift
@@ -55,6 +55,8 @@ final class GreetingViewController: UIViewController {
             .sink { [weak self] event in
                 guard let self = self else { return }
                 switch event {
+                case .updateNickname(let nickname):
+                    updateNickname(nickname)
                 case .moveToHome:
                     if let coordinator = coordinator {
                         coordinator.delegate?.didFinishOnboarding(coordinator)
@@ -68,6 +70,10 @@ final class GreetingViewController: UIViewController {
 
     private func setTitleLabelText() {
         greetingTitleLabel.text = "\(nickname)\(greetingTitleLabel.text ?? "님\n환영합니다")"
+    }
+    
+    private func updateNickname(_ nickname: String) {
+        self.nickname = nickname
     }
 }
 

--- a/QRIZ/Feature/Onboarding/Greeting/ViewController/GreetingViewController.swift
+++ b/QRIZ/Feature/Onboarding/Greeting/ViewController/GreetingViewController.swift
@@ -56,8 +56,9 @@ final class GreetingViewController: UIViewController {
                 guard let self = self else { return }
                 switch event {
                 case .moveToHome:
-                    // coordinator delegate
-                    self.dismiss(animated: true)
+                    if let coordinator = coordinator {
+                        coordinator.delegate?.didFinishOnboarding(coordinator)
+                    }
                 }
             }
             .store(in: &subscriptions)

--- a/QRIZ/Feature/Onboarding/Greeting/ViewController/GreetingViewController.swift
+++ b/QRIZ/Feature/Onboarding/Greeting/ViewController/GreetingViewController.swift
@@ -59,6 +59,8 @@ final class GreetingViewController: UIViewController {
                     if let coordinator = coordinator {
                         coordinator.delegate?.didFinishOnboarding(coordinator)
                     }
+                case .fetchFailed:
+                    showOneButtonAlert(with: "잠시 후 다시 시도해주세요.", storingIn: &subscriptions)
                 }
             }
             .store(in: &subscriptions)

--- a/QRIZ/Feature/Onboarding/Greeting/ViewModel/GreetingViewModel.swift
+++ b/QRIZ/Feature/Onboarding/Greeting/ViewModel/GreetingViewModel.swift
@@ -17,6 +17,7 @@ final class GreetingViewModel {
     }
     
     enum Output {
+        case updateNickname(nickname: String)
         case moveToHome
         case fetchFailed
     }
@@ -40,6 +41,7 @@ final class GreetingViewModel {
             switch event {
             case .viewDidLoad:
                 self.updateUserInfo()
+                output.send(.updateNickname(nickname: UserInfoManager.shared.name))
             case .viewDidAppear:
                 self.startTimer()
             }

--- a/QRIZ/Feature/Onboarding/OnboardingCoordinator.swift
+++ b/QRIZ/Feature/Onboarding/OnboardingCoordinator.swift
@@ -25,7 +25,7 @@ protocol OnboardingCoordinatorDelegate: AnyObject {
 }
 
 @MainActor
-final class OnboardingCoordinatorImp: OnboardingCoordinator {
+final class OnboardingCoordinatorImpl: OnboardingCoordinator {
     
     // MARK: - Properties
     weak var delegate: OnboardingCoordinatorDelegate?
@@ -48,7 +48,8 @@ final class OnboardingCoordinatorImp: OnboardingCoordinator {
             showBeginOnboarding()
         case .surveyCompleted:
             showBeginPreviewTest()
-        default: // case : previewSkipped, previewCompleted
+        default:
+            // case : previewSkipped, previewCompleted
             break
         }
         return navigationController

--- a/QRIZ/Feature/Onboarding/OnboardingCoordinator.swift
+++ b/QRIZ/Feature/Onboarding/OnboardingCoordinator.swift
@@ -31,15 +31,17 @@ final class OnboardingCoordinatorImpl: OnboardingCoordinator {
     weak var delegate: OnboardingCoordinatorDelegate?
     private let navigationController: UINavigationController
     private let onboardingService: OnboardingService
+    private let userInfoService: UserInfoService
     
     var previewTestStatus: PreviewTestStatus {
         UserInfoManager.shared.previewTestStatus
     }
     
     // MARK: - Initializers
-    init(navigationController: UINavigationController, onboardingService: OnboardingService) {
+    init(navigationController: UINavigationController, onboardingService: OnboardingService, userInfoService: UserInfoService) {
         self.navigationController = navigationController
         self.onboardingService = onboardingService
+        self.userInfoService = userInfoService
     }
     
     func start() -> UIViewController {
@@ -91,7 +93,7 @@ final class OnboardingCoordinatorImpl: OnboardingCoordinator {
     }
     
     func showGreeting() {
-        let vm = GreetingViewModel()
+        let vm = GreetingViewModel(userInfoService: userInfoService)
         let vc = GreetingViewController(viewModel: vm)
         vc.coordinator = self
         navigationController.pushViewController(vc, animated: true)

--- a/QRIZ/Feature/Onboarding/OnboardingCoordinator.swift
+++ b/QRIZ/Feature/Onboarding/OnboardingCoordinator.swift
@@ -92,7 +92,7 @@ final class OnboardingCoordinatorImpl: OnboardingCoordinator {
     
     func showGreeting() {
         let vm = GreetingViewModel()
-        let vc = GreetingViewController()
+        let vc = GreetingViewController(viewModel: vm)
         vc.coordinator = self
         navigationController.pushViewController(vc, animated: true)
     }

--- a/QRIZ/Feature/Onboarding/OnboardingCoordinator.swift
+++ b/QRIZ/Feature/Onboarding/OnboardingCoordinator.swift
@@ -1,0 +1,98 @@
+//
+//  OnboardingCoordinator.swift
+//  QRIZ
+//
+//  Created by ch on 6/6/25.
+//
+
+import UIKit
+import Combine
+
+@MainActor
+protocol OnboardingCoordinator: Coordinator {
+    var delegate: OnboardingCoordinatorDelegate? { get set }
+    func showBeginOnboarding()
+    func showCheckConcept()
+    func showBeginPreviewTest()
+    func showPreviewTest()
+    func showPreviewResult()
+    func showGreeting()
+}
+
+@MainActor
+protocol OnboardingCoordinatorDelegate: AnyObject {
+    func didFinishOnboarding(_ coordinator: OnboardingCoordinator)
+}
+
+@MainActor
+final class OnboardingCoordinatorImp: OnboardingCoordinator {
+    
+    // MARK: - Properties
+    weak var delegate: OnboardingCoordinatorDelegate?
+    private let navigationController: UINavigationController
+    private let onboardingService: OnboardingService
+    
+    var previewTestStatus: PreviewTestStatus {
+        UserInfoManager.shared.previewTestStatus
+    }
+    
+    // MARK: - Initializers
+    init(navigationController: UINavigationController, onboardingService: OnboardingService) {
+        self.navigationController = navigationController
+        self.onboardingService = onboardingService
+    }
+    
+    func start() -> UIViewController {
+        switch previewTestStatus {
+        case .notStarted:
+            showBeginOnboarding()
+        case .surveyCompleted:
+            showBeginPreviewTest()
+        default: // case : previewSkipped, previewCompleted
+            break
+        }
+        return navigationController
+    }
+    
+    func showBeginOnboarding() {
+        let vm = BeginOnboardingViewModel()
+        let vc = BeginOnboardingViewController(viewModel: vm)
+        vc.coordinator = self
+        navigationController.pushViewController(vc, animated: true)
+    }
+    
+    func showCheckConcept() {
+        let vm = CheckConceptViewModel(onboardingService: onboardingService)
+        let vc = CheckConceptViewController(viewModel: vm)
+        vc.coordinator = self
+        navigationController.pushViewController(vc, animated: true)
+    }
+    
+    func showBeginPreviewTest() {
+        let vm = BeginPreviewTestViewModel()
+        let vc = BeginPreviewTestViewController(viewModel: vm)
+        vc.coordinator = self
+        navigationController.pushViewController(vc, animated: true)
+    }
+    
+    func showPreviewTest() {
+        let vm = PreviewTestViewModel(onboardingService: onboardingService)
+        let vc = PreviewTestViewController(viewModel: vm)
+        vc.coordinator = self
+        navigationController.pushViewController(vc, animated: true)
+    }
+    
+    func showPreviewResult() {
+        let vm = PreviewResultViewModel(onboardingService: onboardingService)
+        let vc = PreviewResultViewController(viewModel: vm)
+        vc.coordinator = self
+        navigationController.pushViewController(vc, animated: true)
+    }
+    
+    func showGreeting() {
+        let vm = GreetingViewModel()
+        let vc = GreetingViewController()
+        vc.coordinator = self
+        navigationController.pushViewController(vc, animated: true)
+    }
+}

--- a/QRIZ/Feature/Onboarding/PreviewResult/ViewController/PreviewResultViewController.swift
+++ b/QRIZ/Feature/Onboarding/PreviewResult/ViewController/PreviewResultViewController.swift
@@ -14,9 +14,21 @@ final class PreviewResultViewController: UIViewController {
     // MARK: - Properties
     private var previewResultViewHostingController: PreviewResultViewHostingController!
     
-    private var viewModel = PreviewResultViewModel(onboardingService: OnboardingServiceImpl())
+    private var viewModel: PreviewResultViewModel
     private let input: PassthroughSubject<PreviewResultViewModel.Input, Never> = .init()
     private var subscriptions = Set<AnyCancellable>()
+    
+    weak var coordinator: OnboardingCoordinator?
+    
+    // MARK: - Initializers
+    init(viewModel: PreviewResultViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
     
     // MARK: - Methods
     override func viewDidLoad() {
@@ -39,8 +51,7 @@ final class PreviewResultViewController: UIViewController {
                 case .fetchFailed:
                     self.showOneButtonAlert(with: "잠시 후 다시 시도해주세요.", storingIn: &subscriptions)
                 case .moveToGreetingView:
-                    // coordinator role
-                    navigationController?.pushViewController(GreetingViewController(), animated: true)
+                    self.coordinator?.showGreeting()
                 }
             }
             .store(in: &subscriptions)

--- a/QRIZ/Feature/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
+++ b/QRIZ/Feature/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
@@ -96,7 +96,9 @@ final class PreviewTestViewController: UIViewController {
                 case .moveToPreviewResult:
                     self.coordinator?.showPreviewResult()
                 case .moveToHome:
-                    self.dismiss(animated: true)
+                    if let coordinator = self.coordinator {
+                        coordinator.delegate?.didFinishOnboarding(coordinator)
+                    }
                 case .popUpAlert:
                     present(submitAlertViewController, animated: true)
                 case .cancelAlert:

--- a/QRIZ/Feature/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
+++ b/QRIZ/Feature/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
@@ -48,9 +48,21 @@ final class PreviewTestViewController: UIViewController {
     }()
     private let submitAlertViewController = TwoButtonCustomAlertViewController(title: "제출하시겠습니까?", description: "확인 버튼을 누르면 다시 돌아올 수 없어요.")
     
-    private let viewModel: PreviewTestViewModel = PreviewTestViewModel(onboardingService: OnboardingServiceImpl())
+    private let viewModel: PreviewTestViewModel
     private var subscriptions = Set<AnyCancellable>()
     private let input: PassthroughSubject<PreviewTestViewModel.Input, Never> = .init()
+    
+    weak var coordinator: OnboardingCoordinator?
+    
+    // MARK: - Initializers
+    init(viewModel: PreviewTestViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
     
     // MARK: - Methods
     override func viewDidLoad() {
@@ -82,15 +94,15 @@ final class PreviewTestViewController: UIViewController {
                 case .updateTime(let timeLimit, let timeRemaining):
                     updateProgress(timeLimit: timeLimit, timeRemaining: timeRemaining)
                 case .moveToPreviewResult:
-                    self.navigationController?.pushViewController(PreviewResultViewController(), animated: true)
+                    self.coordinator?.showPreviewResult()
                 case .moveToHome:
                     self.dismiss(animated: true)
                 case .popUpAlert:
-                    present(submitAlertViewController, animated: true) // coordniator role
+                    present(submitAlertViewController, animated: true)
                 case .cancelAlert:
-                    submitAlertViewController.dismiss(animated: true) // coordinator role
+                    submitAlertViewController.dismiss(animated: true)
                 case .submitSuccess:
-                    submitAlertViewController.dismiss(animated: true) // coordinator role
+                    submitAlertViewController.dismiss(animated: true)
                 case .submitFail:
                     submitAlertViewController.dismiss(animated: true)
                     self.showOneButtonAlert(with: "잠시 후 다시 시도해주세요.", storingIn: &subscriptions)


### PR DESCRIPTION
## 🛠️ Task

- 온보딩 코디네이터 구현
- 온보딩 및 프리뷰 관련 VC 코디네이터 이용한 로직으로 변경
- AppCoordinator 내부 온보딩 service 및 coordinator 추가

## 🌱 PR Point

- 뷰 전환의 자연스러움 + UserInfoManager.shared 업데이트 및 UserInfoRequest 실패시 alert를 표현하기 위해
didLogin 및 didFinishOnboarding 메서드에서 showSplash() 를 호출하도록 수정했습니다.
- didFinishSplash 내부에 Login <-> Tabbar <-> Onboarding 분기를 지정하도록 수정했습니다.

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |

## 📮 Issue 번호
- resolved: #68 
