### PR TITLE
FEAT: 데일리 및 모의고사 코디네이터 구현

### DIFF
--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 		E27843242DDE152C00E9AD07 /* ExamTestFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27843232DDE152C00E9AD07 /* ExamTestFooterView.swift */; };
 		E27E54A92D6D74C500BF3B55 /* CheckListFoldButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27E54A82D6D74C500BF3B55 /* CheckListFoldButton.swift */; };
 		E2804CF32DFAABD800F5F05D /* DailyCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2804CF22DFAABD800F5F05D /* DailyCoordinator.swift */; };
+		E2804CF52DFAD5D500F5F05D /* ExamCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2804CF42DFAD5D500F5F05D /* ExamCoordinator.swift */; };
 		E283AC082D9E8D8F00DE005B /* TestDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E283AC072D9E8D8F00DE005B /* TestDescriptionView.swift */; };
 		E28A93852D945F95006A15DB /* StudyContentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28A93842D945F94006A15DB /* StudyContentCell.swift */; };
 		E28BAD772D2C111100B8388D /* TwoButtonCustomAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28BAD762D2C111100B8388D /* TwoButtonCustomAlertView.swift */; };
@@ -434,6 +435,7 @@
 		E27843232DDE152C00E9AD07 /* ExamTestFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamTestFooterView.swift; sourceTree = "<group>"; };
 		E27E54A82D6D74C500BF3B55 /* CheckListFoldButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckListFoldButton.swift; sourceTree = "<group>"; };
 		E2804CF22DFAABD800F5F05D /* DailyCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyCoordinator.swift; sourceTree = "<group>"; };
+		E2804CF42DFAD5D500F5F05D /* ExamCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamCoordinator.swift; sourceTree = "<group>"; };
 		E283AC072D9E8D8F00DE005B /* TestDescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDescriptionView.swift; sourceTree = "<group>"; };
 		E28A93842D945F94006A15DB /* StudyContentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyContentCell.swift; sourceTree = "<group>"; };
 		E28BAD762D2C111100B8388D /* TwoButtonCustomAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoButtonCustomAlertView.swift; sourceTree = "<group>"; };
@@ -1351,6 +1353,7 @@
 				E278431A2DDE0DE800E9AD07 /* ExamTest */,
 				E22341A92DD4C26300A67D04 /* ExamSummary */,
 				E25857822DD09E9800AE174C /* ExamList */,
+				E2804CF42DFAD5D500F5F05D /* ExamCoordinator.swift */,
 			);
 			path = Exam;
 			sourceTree = "<group>";
@@ -2033,6 +2036,7 @@
 				E29CCD292D29855B004AA30A /* QuestionNumberLabel.swift in Sources */,
 				E2D70FEE2D0EC037005A3F51 /* CheckConceptViewModel.swift in Sources */,
 				E29CCD2C2D29855B004AA30A /* TestButton.swift in Sources */,
+				E2804CF52DFAD5D500F5F05D /* ExamCoordinator.swift in Sources */,
 				E2A6C0802DBB61890059F960 /* PreviewSubmitRequest.swift in Sources */,
 				E217C3692D9BF0B20095A3D8 /* DailyResultViewModel.swift in Sources */,
 				B18CDF792DD5DF9800DD361A /* TermsAgreementModalViewModel.swift in Sources */,

--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -174,6 +174,7 @@
 		E27843212DDE13B600E9AD07 /* ExamTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27843202DDE13B600E9AD07 /* ExamTestViewController.swift */; };
 		E27843242DDE152C00E9AD07 /* ExamTestFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27843232DDE152C00E9AD07 /* ExamTestFooterView.swift */; };
 		E27E54A92D6D74C500BF3B55 /* CheckListFoldButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27E54A82D6D74C500BF3B55 /* CheckListFoldButton.swift */; };
+		E2804CF32DFAABD800F5F05D /* DailyCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2804CF22DFAABD800F5F05D /* DailyCoordinator.swift */; };
 		E283AC082D9E8D8F00DE005B /* TestDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E283AC072D9E8D8F00DE005B /* TestDescriptionView.swift */; };
 		E28A93852D945F95006A15DB /* StudyContentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28A93842D945F94006A15DB /* StudyContentCell.swift */; };
 		E28BAD772D2C111100B8388D /* TwoButtonCustomAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28BAD762D2C111100B8388D /* TwoButtonCustomAlertView.swift */; };
@@ -432,6 +433,7 @@
 		E27843202DDE13B600E9AD07 /* ExamTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamTestViewController.swift; sourceTree = "<group>"; };
 		E27843232DDE152C00E9AD07 /* ExamTestFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamTestFooterView.swift; sourceTree = "<group>"; };
 		E27E54A82D6D74C500BF3B55 /* CheckListFoldButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckListFoldButton.swift; sourceTree = "<group>"; };
+		E2804CF22DFAABD800F5F05D /* DailyCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyCoordinator.swift; sourceTree = "<group>"; };
 		E283AC072D9E8D8F00DE005B /* TestDescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDescriptionView.swift; sourceTree = "<group>"; };
 		E28A93842D945F94006A15DB /* StudyContentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyContentCell.swift; sourceTree = "<group>"; };
 		E28BAD762D2C111100B8388D /* TwoButtonCustomAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoButtonCustomAlertView.swift; sourceTree = "<group>"; };
@@ -1415,6 +1417,7 @@
 				E2F18BCA2D60606A00DC6F82 /* DailyLearn */,
 				E217C35F2D9BEA500095A3D8 /* DailyTest */,
 				E217C3672D9BF0A10095A3D8 /* DailyResult */,
+				E2804CF22DFAABD800F5F05D /* DailyCoordinator.swift */,
 			);
 			path = Daily;
 			sourceTree = "<group>";
@@ -2158,6 +2161,7 @@
 				54BC61552D14AFB70094DC45 /* LoginInputView.swift in Sources */,
 				E24907DA2D63698C004D6E61 /* DailyLearnSectionTitleLabel.swift in Sources */,
 				E217C3662D9BEAC50095A3D8 /* DailyTestViewModel.swift in Sources */,
+				E2804CF32DFAABD800F5F05D /* DailyCoordinator.swift in Sources */,
 				E2A6C7352DCA4C850059F960 /* ExamService.swift in Sources */,
 				E2908E6B2DB3B55700B8E81B /* ResultDetailHostingController.swift in Sources */,
 				B19C4F6B2D5260DD00CD008A /* UIControl+.swift in Sources */,

--- a/QRIZ/Coordinator/AppCoordinator.swift
+++ b/QRIZ/Coordinator/AppCoordinator.swift
@@ -30,8 +30,9 @@ protocol AppCoordinatorDependency {
     var signUpService: SignUpService { get }
     var accountRecoveryService: AccountRecoveryService { get }
     var examScheduleService: ExamScheduleService { get }
-    var userInfoService: UserInfoService { get }
     var examTestService: ExamService { get }
+    var dailyService: DailyService { get }
+    var userInfoService: UserInfoService { get }
     var onboardingService: OnboardingService { get }
     
     // Utils
@@ -51,6 +52,7 @@ final class AppCoordinatorDependencyImpl: AppCoordinatorDependency {
     lazy var accountRecoveryService: AccountRecoveryService = AccountRecoveryServiceImpl(network: network)
     lazy var examScheduleService: ExamScheduleService = ExamScheduleServiceImpl(network: network, keychain: keychain)
     lazy var examTestService: ExamService = ExamServiceImpl(network: network, keychainManager: keychain)
+    lazy var dailyService: DailyService = DailyServiceImpl(network: network, keychainManager: keychain)
     lazy var userInfoService: UserInfoService = UserInfoServiceImpl(network: network, keychainManager: keychain)
     lazy var onboardingService: OnboardingService = OnboardingServiceImpl(network: network, keychainManager: keychain)
     
@@ -73,6 +75,7 @@ final class AppCoordinatorDependencyImpl: AppCoordinatorDependency {
         let tabBarDependency = TabBarCoordinatorDependencyImp(
             examService: examScheduleService,
             examTestService: examTestService,
+            dailyService: dailyService,
             onboardingService: onboardingService,
             userInfoService: userInfoService
         )

--- a/QRIZ/Coordinator/AppCoordinator.swift
+++ b/QRIZ/Coordinator/AppCoordinator.swift
@@ -31,6 +31,7 @@ protocol AppCoordinatorDependency {
     var accountRecoveryService: AccountRecoveryService { get }
     var examScheduleService: ExamScheduleService { get }
     var userInfoService: UserInfoService { get }
+    var examTestService: ExamService { get }
     var onboardingService: OnboardingService { get }
     
     // Utils
@@ -49,6 +50,7 @@ final class AppCoordinatorDependencyImpl: AppCoordinatorDependency {
     lazy var signUpService: SignUpService = SignUpServiceImpl(network: network)
     lazy var accountRecoveryService: AccountRecoveryService = AccountRecoveryServiceImpl(network: network)
     lazy var examScheduleService: ExamScheduleService = ExamScheduleServiceImpl(network: network, keychain: keychain)
+    lazy var examTestService: ExamService = ExamServiceImpl(network: network, keychainManager: keychain)
     lazy var userInfoService: UserInfoService = UserInfoServiceImpl(network: network, keychainManager: keychain)
     lazy var onboardingService: OnboardingService = OnboardingServiceImpl(network: network, keychainManager: keychain)
     
@@ -70,6 +72,7 @@ final class AppCoordinatorDependencyImpl: AppCoordinatorDependency {
     var tabBarCoordinator: TabBarCoordinator {
         let tabBarDependency = TabBarCoordinatorDependencyImp(
             examService: examScheduleService,
+            examTestService: examTestService,
             onboardingService: onboardingService,
             userInfoService: userInfoService
         )

--- a/QRIZ/Feature/Daily/DailyCoordinator.swift
+++ b/QRIZ/Feature/Daily/DailyCoordinator.swift
@@ -1,0 +1,101 @@
+//
+//  DailyCoordinator.swift
+//  QRIZ
+//
+//  Created by 이창현 on 6/12/25.
+//
+
+import UIKit
+
+@MainActor
+protocol DailyCoordinator: Coordinator {
+    func showDailyLearn()
+    func showConcept(chapter: Chapter, conceptItem: ConceptItem)
+    func showDailyTest()
+    func showDailyResult()
+    func showResultDetail(resultDetailData: ResultDetailData)
+    func dismissModal()
+}
+
+@MainActor
+final class DailyCoordinatorImpl: DailyCoordinator {
+    
+    // MARK: - Properties
+    private let navigationController: UINavigationController
+    private var modalNavigationController: UINavigationController?
+    private let service: DailyService
+    private let day: Int
+    private let type: DailyLearnType
+    
+    // MARK: - Initializers
+    init(
+        navigationController: UINavigationController,
+        dailyService: DailyService,
+        day: Int,
+        type: DailyLearnType) {
+            self.navigationController = navigationController
+            self.service = dailyService
+            self.day = day
+            self.type = type
+        }
+    
+    // MARK: - Methods
+    func start() -> UIViewController {
+        showDailyLearn()
+        return navigationController
+    }
+    
+    func showDailyLearn() {
+        let vm = DailyLearnViewModel(day: day, type: type, dailyService: service)
+        let vc = DailyLearnViewController(dailyLearnViewModel: vm)
+        vc.coordinator = self
+        navigationController.pushViewController(vc, animated: true)
+    }
+    
+    func showConcept(chapter: Chapter, conceptItem: ConceptItem) {
+        let vm = ConceptPDFViewModel(chapter: chapter, conceptItem: conceptItem)
+        let vc = ConceptPDFViewController(conceptPDFViewModel: vm)
+        navigationController.pushViewController(vc, animated: true)
+    }
+    
+    func showDailyTest() {
+        let vm = DailyTestViewModel(dailyTestType: type, day: day, dailyService: service)
+        let vc = DailyTestViewController(viewModel: vm)
+        vc.coordinator = self
+        modalNavigationController = UINavigationController(rootViewController: vc)
+        modalNavigationController?.modalPresentationStyle = .fullScreen
+        if let modal = modalNavigationController {
+            navigationController.present(modal, animated: true)
+        }
+    }
+    
+    func showDailyResult() {
+        let vm = DailyResultViewModel(dailyTestType: type, day: day, dailyService: service)
+        let vc = DailyResultViewController(viewModel: vm)
+        vc.coordinator = self
+        if let modal = modalNavigationController {
+            modal.pushViewController(vc, animated: true)
+        } else {
+            modalNavigationController = UINavigationController(rootViewController: vc)
+            modalNavigationController?.modalPresentationStyle = .fullScreen
+            if let modalNavi = modalNavigationController {
+                navigationController.pushViewController(modalNavi, animated: true)
+            }
+        }
+    }
+    
+    func showResultDetail(resultDetailData: ResultDetailData) {
+        let vm = TestResultDetailViewModel(resultDetailData: resultDetailData)
+        let vc = TestResultDetailViewController(viewModel: vm)
+        if let modal = modalNavigationController {
+            modal.pushViewController(vc, animated: true)
+        }
+    }
+    
+    func dismissModal() {
+        if let modal = modalNavigationController {
+            modal.dismiss(animated: true)
+            modalNavigationController = nil
+        }
+    }
+}

--- a/QRIZ/Feature/Daily/DailyCoordinator.swift
+++ b/QRIZ/Feature/Daily/DailyCoordinator.swift
@@ -61,7 +61,7 @@ final class DailyCoordinatorImpl: DailyCoordinator {
         dailyLearnViewController = vc
         dailyLearnViewModel = vm
         vc.coordinator = self
-        navigationController.pushViewController(vc, animated: true)
+        navigationController.setViewControllers([vc], animated: true)
     }
     
     func showConcept(chapter: Chapter, conceptItem: ConceptItem) {

--- a/QRIZ/Feature/Daily/DailyCoordinator.swift
+++ b/QRIZ/Feature/Daily/DailyCoordinator.swift
@@ -62,6 +62,7 @@ final class DailyCoordinatorImpl: DailyCoordinator {
         let vm = DailyTestViewModel(dailyTestType: type, day: day, dailyService: service)
         let vc = DailyTestViewController(viewModel: vm)
         vc.coordinator = self
+        modalNavigationController = nil
         modalNavigationController = UINavigationController(rootViewController: vc)
         modalNavigationController?.modalPresentationStyle = .fullScreen
         if let modal = modalNavigationController {

--- a/QRIZ/Feature/Daily/DailyCoordinator.swift
+++ b/QRIZ/Feature/Daily/DailyCoordinator.swift
@@ -96,7 +96,7 @@ final class DailyCoordinatorImpl: DailyCoordinator {
         navigationController.pushViewController(vc, animated: true)
     }
     
-    /// Daily 내부에서 테스트나 결과에서 DailyLearn으로 이동하는 메서드
+    /// Daily 내부 테스트나 결과에서 DailyLearn으로 이동하는 메서드
     func quitDaily() {
         if let dailyLearnVC = dailyLearnViewController, let dailyLearnVM = dailyLearnViewModel {
             _ = self.navigationController.popToViewController(dailyLearnVC, animated: true)

--- a/QRIZ/Feature/Daily/DailyLearn/ViewController/DailyLearnViewController.swift
+++ b/QRIZ/Feature/Daily/DailyLearn/ViewController/DailyLearnViewController.swift
@@ -45,6 +45,8 @@ final class DailyLearnViewController: UIViewController {
     private let input: PassthroughSubject<DailyLearnViewModel.Input, Never> = .init()
     private var subscriptions = Set<AnyCancellable>()
     
+    weak var coordinator: DailyCoordinator?
+    
     private var conceptArr: [(Int, String)] = []
     
     // MARK: - Initializer
@@ -91,26 +93,15 @@ final class DailyLearnViewController: UIViewController {
                     self.conceptArr = conceptArr
                     updateCollectionViewHeight()
                 case .moveToDailyTest(let type, let day):
-                    navigationController?.pushViewController(
-                        DailyTestViewController(
-                            viewModel: DailyTestViewModel(
-                                dailyTestType: type,
-                                day: day,
-                                dailyService: DailyServiceImpl())), animated: true)
+                    coordinator?.showDailyTest()
                 case .showRetestAlert:
                     present(retestAlertViewController, animated: true)
                 case .moveToDailyTestResult(let type, let day):
-                    navigationController?.pushViewController(
-                        DailyResultViewController(
-                            viewModel: DailyResultViewModel(
-                                dailyTestType: type,
-                                day: day,
-                                dailyService: DailyServiceImpl())), animated: true)
+                    coordinator?.showDailyResult()
                 case .moveToConcept(let conceptIdx):
-                    navigationController?.pushViewController(ConceptPDFViewController(
-                        conceptPDFViewModel: ConceptPDFViewModel(
-                            chapter: SurveyCheckList.getChapter(conceptIdx - 1),
-                            conceptItem: SurveyCheckList.getConceptItem(conceptIdx - 1))), animated: true)
+                    coordinator?.showConcept(chapter: SurveyCheckList.getChapter(conceptIdx - 1),
+                                             conceptItem: SurveyCheckList.getConceptItem(conceptIdx - 1))
+
                 case .dismissAlert:
                     retestAlertViewController.dismiss(animated: true)
                 }

--- a/QRIZ/Feature/Daily/DailyLearn/ViewModel/DailyLearnViewModel.swift
+++ b/QRIZ/Feature/Daily/DailyLearn/ViewModel/DailyLearnViewModel.swift
@@ -17,6 +17,7 @@ final class DailyLearnViewModel {
         case toConceptClicked(conceptIdx: Int)
         case alertMoveClicked
         case alertCancelClicked
+        case backButtonClicked
     }
     
     enum Output {
@@ -26,11 +27,12 @@ final class DailyLearnViewModel {
         )
         case updateContent(conceptArr: [(Int, String)])
         case fetchFailed(isServerError: Bool)
-        case moveToDailyTest(type: DailyLearnType, day: Int)
+        case moveToDailyTest
         case showRetestAlert
-        case moveToDailyTestResult(type: DailyLearnType, day: Int)
-        case moveToConcept(conceptIdx: Int)
+        case moveToDailyTestResult
+        case moveToConcept(chapter: Chapter, conceptItem: ConceptItem)
         case dismissAlert
+        case moveToHome
     }
     
     // MARK: - Properties
@@ -62,12 +64,15 @@ final class DailyLearnViewModel {
             case .testNavigatorButtonClicked:
                 handleNavigateAction()
             case .toConceptClicked(let conceptIdx):
-                output.send(.moveToConcept(conceptIdx: conceptIdx))
+                output.send(.moveToConcept(chapter: SurveyCheckList.getChapter(conceptIdx - 1),
+                                           conceptItem: SurveyCheckList.getConceptItem(conceptIdx - 1)))
             case .alertMoveClicked:
                 output.send(.dismissAlert)
-                output.send(.moveToDailyTest(type: type, day: day))
+                output.send(.moveToDailyTest)
             case .alertCancelClicked:
                 output.send(.dismissAlert)
+            case .backButtonClicked:
+                output.send(.moveToHome)
             }
         }
         .store(in: &subscriptions)
@@ -127,11 +132,16 @@ final class DailyLearnViewModel {
         case .unavailable:
             return
         case .zeroAttempt:
-            output.send(.moveToDailyTest(type: type, day: day))
+            output.send(.moveToDailyTest)
         case .retestRequired:
             output.send(.showRetestAlert)
         case .passed, .failed:
-            output.send(.moveToDailyTestResult(type: type, day: day))
+            output.send(.moveToDailyTestResult)
         }
+    }
+    
+    func reloadData() {
+        conceptArr = []
+        fetchData()
     }
 }

--- a/QRIZ/Feature/Daily/DailyResult/ViewController/DailyResultViewController.swift
+++ b/QRIZ/Feature/Daily/DailyResult/ViewController/DailyResultViewController.swift
@@ -61,9 +61,13 @@ final class DailyResultViewController: UIViewController {
                         showOneButtonAlert(with: "잠시 후 다시 시도해주세요.", storingIn: &subscriptions)
                     }
                 case .moveToConcept:
-                    print("Move To Concept")
+                    tabBarController?.tabBar.isHidden = false
+                    if let coordinator = coordinator {
+                        coordinator.delegate?.moveFromDailyToConcept(coordinator)
+                    }
+                    
                 case .moveToDailyLearn:
-                    print("Move To Daily Learn")
+                    coordinator?.quitDaily()
                 case .moveToResultDetail:
                     coordinator?.showResultDetail(resultDetailData: self.viewModel.resultDetailData)
                 }

--- a/QRIZ/Feature/Daily/DailyResult/ViewController/DailyResultViewController.swift
+++ b/QRIZ/Feature/Daily/DailyResult/ViewController/DailyResultViewController.swift
@@ -17,6 +17,8 @@ final class DailyResultViewController: UIViewController {
     private let input: PassthroughSubject<DailyResultViewModel.Input, Never> = .init()
     private var subscriptions = Set<AnyCancellable>()
     
+    weak var coordinator: DailyCoordinator?
+    
     // MARK: - Initializers
     init(viewModel: DailyResultViewModel) {
         self.viewModel = viewModel
@@ -63,9 +65,7 @@ final class DailyResultViewController: UIViewController {
                 case .moveToDailyLearn:
                     print("Move To Daily Learn")
                 case .moveToResultDetail:
-                    let vm = TestResultDetailViewModel(resultDetailData: self.viewModel.resultDetailData)
-                    let vc = TestResultDetailViewController(viewModel: vm)
-                    self.navigationController?.pushViewController(vc, animated: true)
+                    coordinator?.showResultDetail(resultDetailData: self.viewModel.resultDetailData)
                 }
             }
             .store(in: &subscriptions)

--- a/QRIZ/Feature/Daily/DailyTest/ViewController/DailyTestViewController.swift
+++ b/QRIZ/Feature/Daily/DailyTest/ViewController/DailyTestViewController.swift
@@ -90,7 +90,7 @@ final class DailyTestViewController: UIViewController {
                 case .moveToDailyResult(let type, let day):
                     coordinator?.showDailyResult()
                 case .moveToHomeView:
-                    coordinator?.dismissModal()
+                    coordinator?.quitDaily()
                 case .popSubmitAlert:
                     present(submitAlertViewController, animated: true)
                 case .cancelAlert:

--- a/QRIZ/Feature/Daily/DailyTest/ViewController/DailyTestViewController.swift
+++ b/QRIZ/Feature/Daily/DailyTest/ViewController/DailyTestViewController.swift
@@ -27,6 +27,8 @@ final class DailyTestViewController: UIViewController {
     
     private let submitAlertViewController = TwoButtonCustomAlertViewController(title: "제출하시겠습니까?", description: "확인 버튼을 누르면 다시 돌아올 수 없어요.")
     
+    weak var coordinator: DailyCoordinator?
+    
     // MARK: - Initializers
     init(viewModel: DailyTestViewModel) {
         self.viewModel = viewModel
@@ -86,9 +88,9 @@ final class DailyTestViewController: UIViewController {
                 case .alterButtonText:
                     footerView.alterButtonText()
                 case .moveToDailyResult(let type, let day):
-                    self.navigationController?.pushViewController(DailyResultViewController(viewModel: DailyResultViewModel(dailyTestType: type, day: day, dailyService: DailyServiceImpl())), animated: true)
+                    coordinator?.showDailyResult()
                 case .moveToHomeView:
-                    print("Move To Home View")
+                    coordinator?.dismissModal()
                 case .popSubmitAlert:
                     present(submitAlertViewController, animated: true)
                 case .cancelAlert:

--- a/QRIZ/Feature/Exam/ExamCoordinator.swift
+++ b/QRIZ/Feature/Exam/ExamCoordinator.swift
@@ -21,7 +21,7 @@ protocol ExamCoordinator: Coordinator {
 @MainActor
 protocol ExamCoordinatorDelegate: AnyObject {
     func didQuitExam(_ coordinator: ExamCoordinator)
-    func moveToConcept(_ coordinator: ExamCoordinator)
+    func moveFromExamToConcept(_ coordinator: ExamCoordinator)
 }
 
 @MainActor
@@ -30,8 +30,8 @@ final class ExamCoordinatorImpl: ExamCoordinator {
     // MARK: - Properties
     weak var delegate: ExamCoordinatorDelegate?
     private let navigationController: UINavigationController
-    private weak var examListViewController: UIViewController?
-    private weak var examListViewModel: ExamListViewModel?
+    private var examListViewController: UIViewController?
+    private var examListViewModel: ExamListViewModel?
     private let service: ExamService
     
     // MARK: - Initializers

--- a/QRIZ/Feature/Exam/ExamCoordinator.swift
+++ b/QRIZ/Feature/Exam/ExamCoordinator.swift
@@ -1,0 +1,91 @@
+//
+//  ExamCoordinator.swift
+//  QRIZ
+//
+//  Created by 이창현 on 6/12/25.
+//
+
+import UIKit
+
+@MainActor
+protocol ExamCoordinator: Coordinator {
+    var delegate: ExamCoordinatorDelegate? { get set }
+    func showExamList()
+    func showExamSummary(examId: Int)
+    func showExamTest(examId: Int)
+    func showExamResult(examId: Int)
+    func showResultDetail(resultDetailData: ResultDetailData)
+    func quitExam()
+}
+
+@MainActor
+protocol ExamCoordinatorDelegate: AnyObject {
+    func didQuitExam(_ coordinator: ExamCoordinator)
+    func moveToConcept(_ coordinator: ExamCoordinator)
+}
+
+@MainActor
+final class ExamCoordinatorImpl: ExamCoordinator {
+    
+    // MARK: - Properties
+    weak var delegate: ExamCoordinatorDelegate?
+    private let navigationController: UINavigationController
+    private weak var examListViewController: UIViewController?
+    private weak var examListViewModel: ExamListViewModel?
+    private let service: ExamService
+    
+    // MARK: - Initializers
+    init(navigationController: UINavigationController, examService: ExamService) {
+        self.navigationController = navigationController
+        self.service = examService
+    }
+    
+    // MARK: - Methods
+    func start() -> UIViewController {
+        showExamList()
+        return navigationController
+    }
+    
+    func showExamList() {
+        let vm = ExamListViewModel(examService: service)
+        let vc = ExamListViewController(viewModel: vm)
+        vc.coordinator = self
+        examListViewController = vc
+        examListViewModel = vm
+        self.navigationController.pushViewController(vc, animated: true)
+    }
+    
+    func showExamSummary(examId: Int) {
+        let vm = ExamSummaryViewModel(examId: examId)
+        let vc = ExamSummaryViewController(viewModel: vm)
+        vc.coordinator = self
+        self.navigationController.pushViewController(vc, animated: true)
+    }
+    
+    func showExamTest(examId: Int) {
+        let vm = ExamTestViewModel(examId: examId, examService: service)
+        let vc = ExamTestViewController(viewModel: vm)
+        vc.coordinator = self
+        self.navigationController.pushViewController(vc, animated: true)
+    }
+    
+    func showExamResult(examId: Int) {
+        let vm = ExamResultViewModel(examId: examId, examService: service)
+        let vc = ExamResultViewController(viewModel: vm)
+        vc.coordinator = self
+        self.navigationController.pushViewController(vc, animated: true)
+    }
+    
+    func showResultDetail(resultDetailData: ResultDetailData) {
+        let vm = TestResultDetailViewModel(resultDetailData: resultDetailData)
+        let vc = TestResultDetailViewController(viewModel: vm)
+        self.navigationController.pushViewController(vc, animated: true)
+    }
+    
+    func quitExam() {
+        if let examListVC = examListViewController, let examListVM = examListViewModel {
+            _ = self.navigationController.popToViewController(examListVC, animated: true)
+            examListVM.reloadList()
+        }
+    }
+}

--- a/QRIZ/Feature/Exam/ExamCoordinator.swift
+++ b/QRIZ/Feature/Exam/ExamCoordinator.swift
@@ -20,6 +20,7 @@ protocol ExamCoordinator: Coordinator {
 
 @MainActor
 protocol ExamCoordinatorDelegate: AnyObject {
+    /// ExamCoordinator 자체를 벗어나 홈으로 이동하는 메서드
     func didQuitExam(_ coordinator: ExamCoordinator)
     func moveFromExamToConcept(_ coordinator: ExamCoordinator)
 }
@@ -82,6 +83,7 @@ final class ExamCoordinatorImpl: ExamCoordinator {
         self.navigationController.pushViewController(vc, animated: true)
     }
     
+    /// Exam 내부 테스트나 결과에서 ExamList로 이동하는 메서드
     func quitExam() {
         if let examListVC = examListViewController, let examListVM = examListViewModel {
             _ = self.navigationController.popToViewController(examListVC, animated: true)

--- a/QRIZ/Feature/Exam/ExamList/ViewController/ExamListViewController.swift
+++ b/QRIZ/Feature/Exam/ExamList/ViewController/ExamListViewController.swift
@@ -31,6 +31,9 @@ final class ExamListViewController: UIViewController {
     private let input: PassthroughSubject<ExamListViewModel.Input, Never> = .init()
     private var subscriptions = Set<AnyCancellable>()
     
+    weak var coordinator: ExamCoordinator?
+    
+    // MARK: - Initializers
     init(viewModel: ExamListViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
@@ -50,6 +53,7 @@ final class ExamListViewController: UIViewController {
         bind()
         input.send(.viewDidLoad)
         addClearViewAction()
+        tabBarController?.tabBar.isHidden = true
     }
     
     private func bind() {
@@ -74,9 +78,13 @@ final class ExamListViewController: UIViewController {
                     examListFilterItemsView.isHidden = !isVisible
                     customClearView.isHidden = !isVisible
                 case .moveToExamView(let examId):
-                    self.navigationController?.pushViewController(ExamSummaryViewController(viewModel: ExamSummaryViewModel(examId: examId)), animated: true)
+                    coordinator?.showExamSummary(examId: examId)
                 case .cancelExamListView:
                     self.dismiss(animated: true)
+                    tabBarController?.tabBar.isHidden = false
+                    if let coordinator = coordinator {
+                        coordinator.delegate?.didQuitExam(coordinator)
+                    }
                 }
             }
             .store(in: &subscriptions)

--- a/QRIZ/Feature/Exam/ExamList/ViewController/ExamListViewController.swift
+++ b/QRIZ/Feature/Exam/ExamList/ViewController/ExamListViewController.swift
@@ -80,7 +80,6 @@ final class ExamListViewController: UIViewController {
                 case .moveToExamView(let examId):
                     coordinator?.showExamSummary(examId: examId)
                 case .cancelExamListView:
-                    self.dismiss(animated: true)
                     tabBarController?.tabBar.isHidden = false
                     if let coordinator = coordinator {
                         coordinator.delegate?.didQuitExam(coordinator)

--- a/QRIZ/Feature/Exam/ExamList/ViewModel/ExamListViewModel.swift
+++ b/QRIZ/Feature/Exam/ExamList/ViewModel/ExamListViewModel.swift
@@ -96,4 +96,9 @@ final class ExamListViewModel {
         self.isFilterItemsPresented = false
         output.send(.setFilterItemsVisibility(isVisible: self.isFilterItemsPresented))
     }
+    
+    func reloadList() {
+        self.filterSelected = .total
+        fetchData()
+    }
 }

--- a/QRIZ/Feature/Exam/ExamResult/ViewController/ExamResultViewController.swift
+++ b/QRIZ/Feature/Exam/ExamResult/ViewController/ExamResultViewController.swift
@@ -63,7 +63,7 @@ final class ExamResultViewController: UIViewController {
                 case .moveToConcept:
                     tabBarController?.tabBar.isHidden = false
                     if let coordinator = coordinator {
-                        coordinator.delegate?.moveToConcept(coordinator)
+                        coordinator.delegate?.moveFromExamToConcept(coordinator)
                     }
                 case .moveToExamList:
                     coordinator?.quitExam()

--- a/QRIZ/Feature/Exam/ExamResult/ViewController/ExamResultViewController.swift
+++ b/QRIZ/Feature/Exam/ExamResult/ViewController/ExamResultViewController.swift
@@ -17,6 +17,8 @@ final class ExamResultViewController: UIViewController {
     private let input: PassthroughSubject<ExamResultViewModel.Input, Never> = .init()
     private var subscriptions = Set<AnyCancellable>()
     
+    weak var coordinator: ExamCoordinator?
+    
     // MARK: - Initializers
     init(viewModel: ExamResultViewModel) {
         self.viewModel = viewModel
@@ -59,13 +61,14 @@ final class ExamResultViewController: UIViewController {
                         showOneButtonAlert(with: "잠시 후 다시 시도해주세요.", storingIn: &subscriptions)
                     }
                 case .moveToConcept:
-                    print("Move To Concept")
+                    tabBarController?.tabBar.isHidden = false
+                    if let coordinator = coordinator {
+                        coordinator.delegate?.moveToConcept(coordinator)
+                    }
                 case .moveToExamList:
-                    print("Move To ExamList")
+                    coordinator?.quitExam()
                 case .moveToResultDetail:
-                    let vm = TestResultDetailViewModel(resultDetailData: self.viewModel.resultDetailData)
-                    let vc = TestResultDetailViewController(viewModel: vm)
-                    self.navigationController?.pushViewController(vc, animated: true)
+                    coordinator?.showResultDetail(resultDetailData: self.viewModel.resultDetailData)
                 }
             }
             .store(in: &subscriptions)

--- a/QRIZ/Feature/Exam/ExamResult/ViewModel/ExamResultViewModel.swift
+++ b/QRIZ/Feature/Exam/ExamResult/ViewModel/ExamResultViewModel.swift
@@ -16,7 +16,6 @@ final class ExamResultViewModel {
         case cancelButtonClicked
         case moveToConceptButtonClicked
         case resultDetailButtonClicked
-        case scoreGraphFilterSelected(filterType: ScoreGraphFilterType)
     }
     
     enum Output {
@@ -68,8 +67,6 @@ final class ExamResultViewModel {
                 output.send(.moveToConcept)
             case .resultDetailButtonClicked:
                 output.send(.moveToResultDetail)
-            case .scoreGraphFilterSelected(let filterType):
-                print("YEYE")
             }
         }
         .store(in: &subscriptions)

--- a/QRIZ/Feature/Exam/ExamSummary/ViewController/ExamSummaryViewController.swift
+++ b/QRIZ/Feature/Exam/ExamSummary/ViewController/ExamSummaryViewController.swift
@@ -38,6 +38,8 @@ final class ExamSummaryViewController: UIViewController {
     private let input: PassthroughSubject<ExamSummaryViewModel.Input, Never> = .init()
     private var subscriptions = Set<AnyCancellable>()
     
+    weak var coordinator: ExamCoordinator?
+    
     // MARK: - Initializers
     init(viewModel: ExamSummaryViewModel) {
         self.viewModel = viewModel
@@ -76,13 +78,7 @@ final class ExamSummaryViewController: UIViewController {
                 guard let self = self else { return }
                 switch event {
                 case .moveToExam(let examId):
-                    let vc = UINavigationController(
-                        rootViewController: ExamTestViewController(
-                            viewModel: ExamTestViewModel(
-                            examId: examId,
-                            examService: ExamServiceImpl())))
-                    vc.modalPresentationStyle = .fullScreen
-                    present(vc, animated: true)
+                    coordinator?.showExamTest(examId: examId)
                 }
             }
             .store(in: &subscriptions)

--- a/QRIZ/Feature/Exam/ExamTest/ViewController/ExamTestViewController.swift
+++ b/QRIZ/Feature/Exam/ExamTest/ViewController/ExamTestViewController.swift
@@ -28,6 +28,8 @@ final class ExamTestViewController: UIViewController {
     
     private let submitAlertViewController = TwoButtonCustomAlertViewController(title: "제출하시겠습니까?", description: "확인 버튼을 누르면 다시 돌아올 수 없어요.")
     
+    weak var coordinator: ExamCoordinator?
+    
     // MARK: - Initializers
     init(viewModel: ExamTestViewModel) {
         self.viewModel = viewModel
@@ -94,10 +96,10 @@ final class ExamTestViewController: UIViewController {
                     footerView.updateNextButton(isVisible: isVisible, isTextSubmit: isTextSubmit)
                 case .moveToExamResult(let examId):
                     removeNavigationItems()
-                    self.navigationController?.pushViewController(ExamResultViewController(viewModel: ExamResultViewModel(examId: examId, examService: ExamServiceImpl())), animated: true)
+                    coordinator?.showExamResult(examId: examId)
                 case .moveToExamList:
                     removeNavigationItems()
-                    self.dismiss(animated: true)
+                    coordinator?.quitExam()
                 case .popSubmitAlert:
                     present(submitAlertViewController, animated: true)
                 case .cancelAlert:

--- a/QRIZ/Feature/Home/ViewController/HomeViewController.swift
+++ b/QRIZ/Feature/Home/ViewController/HomeViewController.swift
@@ -72,8 +72,7 @@ final class HomeViewController: UIViewController {
                     self.coordinator?.showOnboarding()
                     
                 case .navigateToExamList:
-                    // TODO: - Coordinator 연결 필요
-                    print("Coordinator 연결")
+                    self.coordinator?.showExam()
                 }
             }
             .store(in: &cancellables)

--- a/QRIZ/Feature/TabBar/TabBarCoordinator.swift
+++ b/QRIZ/Feature/TabBar/TabBarCoordinator.swift
@@ -30,6 +30,7 @@ final class TabBarCoordinatorDependencyImp: TabBarCoordinatorDependency {
     
     private let examService: ExamScheduleService
     private let examTestService: ExamService
+    private let dailyService: DailyService
     private let onboardingService: OnboardingService
     private let userInfoService: UserInfoService
     
@@ -37,6 +38,7 @@ final class TabBarCoordinatorDependencyImp: TabBarCoordinatorDependency {
         return HomeCoordinatorImpl(
             examService: examService,
             examTestService: examTestService,
+            dailyService: dailyService,
             onboardingService: onboardingService,
             userInfoService: userInfoService
         )
@@ -57,11 +59,13 @@ final class TabBarCoordinatorDependencyImp: TabBarCoordinatorDependency {
     init(
         examService: ExamScheduleService,
         examTestService: ExamService,
+        dailyService: DailyService,
         onboardingService: OnboardingService,
         userInfoService: UserInfoService
     ) {
         self.examService = examService
         self.examTestService = examTestService
+        self.dailyService = dailyService
         self.onboardingService = onboardingService
         self.userInfoService = userInfoService
     }

--- a/QRIZ/Feature/TabBar/TabBarCoordinator.swift
+++ b/QRIZ/Feature/TabBar/TabBarCoordinator.swift
@@ -29,12 +29,14 @@ protocol TabBarCoordinatorDependency {
 final class TabBarCoordinatorDependencyImp: TabBarCoordinatorDependency {
     
     private let examService: ExamScheduleService
+    private let examTestService: ExamService
     private let onboardingService: OnboardingService
     private let userInfoService: UserInfoService
     
     var homeCoordinator: HomeCoordinator {
         return HomeCoordinatorImpl(
             examService: examService,
+            examTestService: examTestService,
             onboardingService: onboardingService,
             userInfoService: userInfoService
         )
@@ -54,10 +56,12 @@ final class TabBarCoordinatorDependencyImp: TabBarCoordinatorDependency {
     
     init(
         examService: ExamScheduleService,
+        examTestService: ExamService,
         onboardingService: OnboardingService,
         userInfoService: UserInfoService
     ) {
         self.examService = examService
+        self.examTestService = examTestService
         self.onboardingService = onboardingService
         self.userInfoService = userInfoService
     }
@@ -69,6 +73,7 @@ final class TabBarCoordinatorImp: TabBarCoordinator {
     weak var delegate: TabBarCoordinatorDelegate?
     var childCoordinators: [Coordinator] = []
     private let dependency: TabBarCoordinatorDependency
+    private var tabBarController: UITabBarController?
     
     init(dependency: TabBarCoordinatorDependency) {
         self.dependency = dependency
@@ -82,6 +87,8 @@ final class TabBarCoordinatorImp: TabBarCoordinator {
         let conceptBookCoordinator = dependency.conceptBookCoordinator
         let mistakeNoteCoordinator = dependency.mistakeNoteCoordinator
         let myPageCoordinator = dependency.myPageCoordinator
+        
+        homeCoordinator.delegate = self
         
         childCoordinators.append(contentsOf: [
             homeCoordinator,
@@ -98,6 +105,9 @@ final class TabBarCoordinatorImp: TabBarCoordinator {
         setupTabBarItems(for: &viewControllers)
         
         tabBarController.viewControllers = viewControllers
+        
+        self.tabBarController = tabBarController
+        
         return tabBarController
     }
     
@@ -137,5 +147,14 @@ final class TabBarCoordinatorImp: TabBarCoordinator {
     
     func logout() {
         delegate?.didLogout(self)
+    }
+}
+
+@MainActor
+extension TabBarCoordinatorImp: HomeCoordinatorDelegate {
+    func moveToConcept() {
+        if let tabBarController = self.tabBarController {
+            tabBarController.selectedIndex = 1
+        }
     }
 }


### PR DESCRIPTION
## 🛠️ Task

- 데일리 코디네이터 구현
- 모의고사 코디네이터 구현

## 🌱 PR Point

- 데일리 및 모의고사 코디네이터를 구현했습니다.
- 데일리 및 모의고사에서 탭바 아이템의 '개념서'가 선택되어야하는 경우가 있기 때문에, TabBarCoordinator와 HomeCoordinator에 각각 Delegate를 추가했습니다.
- 홈의 모의고사 응시하기를 통해 ExamCoordinator로 연결되도록 구현했습니다.
- 데일리의 경우에도 모의고사와 비슷하되, showDaily(day: Int, type: DailyLearnType)를 통해 호출되도록 구현했습니다.

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |

## 📮 Issue 번호
- resolved: #70 
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 