### PR TITLE
HOTFIX: 시험 결과 메모리 누수

### DIFF
--- a/QRIZ/Feature/Daily/DailyCoordinator.swift
+++ b/QRIZ/Feature/Daily/DailyCoordinator.swift
@@ -61,7 +61,7 @@ final class DailyCoordinatorImpl: DailyCoordinator {
         dailyLearnViewController = vc
         dailyLearnViewModel = vm
         vc.coordinator = self
-        navigationController.setViewControllers([vc], animated: true)
+        navigationController.pushViewController(vc, animated: true)
     }
     
     func showConcept(chapter: Chapter, conceptItem: ConceptItem) {

--- a/QRIZ/Feature/Daily/DailyLearn/ViewModel/DailyLearnViewModel.swift
+++ b/QRIZ/Feature/Daily/DailyLearn/ViewModel/DailyLearnViewModel.swift
@@ -80,7 +80,8 @@ final class DailyLearnViewModel {
     }
     
     private func fetchData() {
-        Task {
+        Task { [weak self] in
+            guard let self = self else { return }
             do {
                 let response = try await dailyService.getDailyDetailAndStatus(dayNumber: day)
                 let status = response.data.status

--- a/QRIZ/Feature/Daily/DailyResult/View/DailyResultView.swift
+++ b/QRIZ/Feature/Daily/DailyResult/View/DailyResultView.swift
@@ -10,9 +10,9 @@ import Combine
 
 struct DailyResultView: View {
     
-    @StateObject var resultScoresData: ResultScoresData
-    @StateObject var resultGradeListData: ResultGradeListData
-    @StateObject var resultDetailData: ResultDetailData
+    @ObservedObject var resultScoresData: ResultScoresData
+    @ObservedObject var resultGradeListData: ResultGradeListData
+    @ObservedObject var resultDetailData: ResultDetailData
     @State var dailyLearnType: DailyLearnType
     
     private let contentsInput: PassthroughSubject<Void, Never> = .init()

--- a/QRIZ/Feature/Daily/DailyResult/ViewModel/DailyResultViewModel.swift
+++ b/QRIZ/Feature/Daily/DailyResult/ViewModel/DailyResultViewModel.swift
@@ -78,7 +78,8 @@ final class DailyResultViewModel {
     }
     
     private func fetchData() {
-        Task {
+        Task { [weak self] in
+            guard let self = self else { return }
             do {
                 if dailyTestType == .weekly {
                     try await fetchWeeklyResult()

--- a/QRIZ/Feature/Daily/DailyTest/ViewModel/DailyTestViewModel.swift
+++ b/QRIZ/Feature/Daily/DailyTest/ViewModel/DailyTestViewModel.swift
@@ -96,7 +96,8 @@ final class DailyTestViewModel {
     }
     
     private func fetchData() {
-        Task {
+        Task { [weak self] in
+            guard let self = self else { return }
             do {
                 let response = try await dailyService.getDailyTestList(dayNumber: day)
                 guard let data = response.data else { throw NetworkError.unknownError }
@@ -195,7 +196,8 @@ final class DailyTestViewModel {
     }
     
     private func sendSubmitData() {
-        Task {
+        Task { [weak self] in
+            guard let self = self else { return }
             do {
                 let _ = try await dailyService.submitDaily(dayNumber: day, dailySubmitData: submitData)
                 exitTimer()

--- a/QRIZ/Feature/Exam/ExamList/ViewModel/ExamListViewModel.swift
+++ b/QRIZ/Feature/Exam/ExamList/ViewModel/ExamListViewModel.swift
@@ -71,7 +71,8 @@ final class ExamListViewModel {
     }
     
     private func fetchData() {
-        Task {
+        Task { [weak self] in
+            guard let self = self else { return }
             do {
                 let response = try await examService.getExamList(filterType: filterSelected)
                 examList = response.data

--- a/QRIZ/Feature/Exam/ExamResult/View/ExamResultView.swift
+++ b/QRIZ/Feature/Exam/ExamResult/View/ExamResultView.swift
@@ -10,10 +10,10 @@ import Combine
 
 struct ExamResultView: View {
     
-    @StateObject var resultScoresData: ResultScoresData
-    @StateObject var resultGradeListData: ResultGradeListData
-    @StateObject var resultDetailData: ResultDetailData
-    @StateObject var scoreGraphData: ScoreGraphData
+    @ObservedObject var resultScoresData: ResultScoresData
+    @ObservedObject var resultGradeListData: ResultGradeListData
+    @ObservedObject var resultDetailData: ResultDetailData
+    @ObservedObject var scoreGraphData: ScoreGraphData
     
     private let contentsInput: PassthroughSubject<Void, Never> = .init()
     private let footerInput: PassthroughSubject<Void, Never> = .init()

--- a/QRIZ/Feature/Exam/ExamResult/ViewModel/ExamResultViewModel.swift
+++ b/QRIZ/Feature/Exam/ExamResult/ViewModel/ExamResultViewModel.swift
@@ -74,7 +74,8 @@ final class ExamResultViewModel {
     }
     
     private func fetchData() {
-        Task {
+        Task { [weak self] in
+            guard let self = self else { return }
             do {
                 try await fetchResultResponse()
                 try await fetchScoreResponse()

--- a/QRIZ/Feature/Exam/ExamTest/ViewModel/ExamTestViewModel.swift
+++ b/QRIZ/Feature/Exam/ExamTest/ViewModel/ExamTestViewModel.swift
@@ -94,7 +94,8 @@ final class ExamTestViewModel {
     }
     
     private func fetchData() {
-        Task {
+        Task { [weak self] in
+            guard let self = self else { return }
             do {
                 let response = try await examService.getExamQuestion(examId: examId)
                 let data = response.data
@@ -127,7 +128,8 @@ final class ExamTestViewModel {
     }
     
     private func sendSubmitData() {
-        Task {
+        Task { [weak self] in
+            guard let self = self else { return }
             do {
                 let _ = try await examService.submitTest(examId: examId, testSubmitData: submitData)
                 exitTimer()

--- a/QRIZ/Feature/Onboarding/CheckConcept/ViewModel/CheckConceptViewModel.swift
+++ b/QRIZ/Feature/Onboarding/CheckConcept/ViewModel/CheckConceptViewModel.swift
@@ -121,7 +121,8 @@ final class CheckConceptViewModel {
     }
     
     private func sendSurvey() {
-        Task {
+        Task { [weak self] in
+            guard let self = self else { return }
             do {
                 if isDoneButtonActivated {
                     let keyConcepts = selectedSet.map { SurveyCheckList.list[$0] }
@@ -130,7 +131,7 @@ final class CheckConceptViewModel {
                     if selectedSet.isEmpty {
                         output.send(.moveToGreeting)
                     } else {
-                        self.output.send(.moveToBeginPreviewTest)
+                        output.send(.moveToBeginPreviewTest)
                     }
                 }
             } catch {

--- a/QRIZ/Feature/Onboarding/Greeting/ViewModel/GreetingViewModel.swift
+++ b/QRIZ/Feature/Onboarding/Greeting/ViewModel/GreetingViewModel.swift
@@ -61,7 +61,8 @@ final class GreetingViewModel {
     }
     
     private func updateUserInfo() {
-        Task {
+        Task { [weak self] in
+            guard let self = self else { return }
             do {
                 let response = try await userInfoService.getUserInfo()
                 UserInfoManager.shared.update(from: response.data)

--- a/QRIZ/Feature/Onboarding/PreviewResult/View/PreviewResultView.swift
+++ b/QRIZ/Feature/Onboarding/PreviewResult/View/PreviewResultView.swift
@@ -10,8 +10,8 @@ import Combine
 
 struct PreviewResultView: View {
     
-    @StateObject var previewScoresData: ResultScoresData
-    @StateObject var previewConceptsData: PreviewConceptsData
+    @ObservedObject var previewScoresData: ResultScoresData
+    @ObservedObject var previewConceptsData: PreviewConceptsData
     
     var body: some View {
         ScrollView(.vertical) {

--- a/QRIZ/Feature/Onboarding/PreviewResult/ViewModel/PreviewResultViewModel.swift
+++ b/QRIZ/Feature/Onboarding/PreviewResult/ViewModel/PreviewResultViewModel.swift
@@ -52,7 +52,8 @@ final class PreviewResultViewModel {
     }
     
     private func analyzePreviewResult() {
-        Task {
+        Task { [weak self] in
+            guard let self = self else { return }
             do {
                 let response = try await onboardingService.analyzePreview()
                 updateData(response.data)

--- a/QRIZ/Feature/Onboarding/PreviewTest/ViewModel/PreviewTestViewModel.swift
+++ b/QRIZ/Feature/Onboarding/PreviewTest/ViewModel/PreviewTestViewModel.swift
@@ -86,7 +86,8 @@ final class PreviewTestViewModel {
     }
     
     private func submitHandler() {
-        Task {
+        Task { [weak self] in
+            guard let self = self else { return }
             do {
                 let _ = try await onboardingService.submitPreview(testSubmitDataList: submitList)
                 exitTimer()
@@ -122,7 +123,8 @@ final class PreviewTestViewModel {
     }
     
     private func getPreviewTestList() {
-        Task {
+        Task { [weak self] in
+            guard let self = self else { return }
             do {
                 let response = try await onboardingService.getPreviewTestList()
                 let questions = response.data.questions

--- a/QRIZ/Feature/TestComponents/TestResultDetail/ViewModel/TestResultDetailViewModel.swift
+++ b/QRIZ/Feature/TestComponents/TestResultDetail/ViewModel/TestResultDetailViewModel.swift
@@ -14,7 +14,10 @@ final class TestResultDetailViewModel: ResultDetailViewModel {
     init(resultDetailData: ResultDetailData) {
             self.resultDetailData = resultDetailData
             super.init()
-            Task { await self.setScoresData(.total) }
+            Task { [weak self] in
+                guard let self = self else { return }
+                await setScoresData(.total)
+            }
     }
     
     // MARK: - Properties
@@ -31,7 +34,10 @@ final class TestResultDetailViewModel: ResultDetailViewModel {
             guard let self = self else { return }
             switch event {
             case .menuItemSelected(let selected):
-                Task { await self.setScoresData(selected) }
+                Task { [weak self] in
+                    guard let self = self else { return }
+                    await setScoresData(selected)
+                }
             }
         }
         .store(in: &subscriptions)

--- a/QRIZ/Feature/TestComponents/View/ResultDetailView.swift
+++ b/QRIZ/Feature/TestComponents/View/ResultDetailView.swift
@@ -10,7 +10,7 @@ import Combine
 
 struct ResultDetailView: View {
     
-    @StateObject var resultScoreData: ResultScoresData
+    @ObservedObject var resultScoreData: ResultScoresData
     @ObservedObject var resultDetailData: ResultDetailData
     let input: PassthroughSubject<ResultDetailViewModel.Input, Never> = .init()
     


### PR DESCRIPTION
## 🛠️ Task

- 프리뷰 시험 결과 메모리 누수 제거
- 데일리 시험 결과 메모리 누수 제거
- 모의고사 시험 결과 메모리 누수 제거
- 프리뷰, 데일리, 모의고사 일부 메서드의 Task 내부 weak self 캡쳐 추가

## 🌱 PR Point

- StateObject 키워드를 ObservedObject로 수정해서 ViewModel이 해당 모델들을 전적으로 관리하도록 수정했습니다.
- 프리뷰, 데일리, 모의고사 내부 Task에 weak self를 추가했습니다.
- DailyCoordinator의 showDailyLearn 메서드 내부 setViewControllers를 pushViewController로 수정했습니다.

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |

## 📮 Issue 번호
- resolved: #74 
