### PR TITLE
FIX: 마이페이지 비밀번호 재설정 코디네이터 로직 수정

### DIFF
--- a/Network/DTOs/Auth/AccountRecovery/PasswordResetRequest.swift
+++ b/Network/DTOs/Auth/AccountRecovery/PasswordResetRequest.swift
@@ -36,9 +36,13 @@ struct PasswordResetRequest: Request {
     let path = "/api/pwd-reset"
     let method: HTTPMethod = .post
     let password: String
+    let resetToken: String
     
     var body: Encodable? {
-        ["password": password]
+        [
+            "newPassword": password,
+            "resetToken": resetToken
+        ]
     }
     
     var headers: HTTPHeader {

--- a/Network/DTOs/Auth/AccountRecovery/VerifyPasswordResetRequest.swift
+++ b/Network/DTOs/Auth/AccountRecovery/VerifyPasswordResetRequest.swift
@@ -5,24 +5,6 @@
 //  Created by 김세훈 on 3/19/25.
 //
 
-/*
- 실패
- 
- {
-     "code": -1,
-     "msg": "인증번호가 유효하지 않거나 만료되었습니다",
-     "data": null
- }
- 
- 성공
- 
- {
-     "code": 1,
-     "msg": "인증이 완료되었습니다",
-     "data": null
- }
- */
-
 import Foundation
 
 struct VerifyPasswordResetRequest: Request {
@@ -48,4 +30,9 @@ struct VerifyPasswordResetRequest: Request {
 struct VerifyPasswordResetResponse: Decodable {
     let code: Int
     let msg: String
+    let data: DataInfo
+    
+    struct DataInfo: Decodable {
+        let resetToken: String
+    }
 }

--- a/Network/Service/Auth/AccountRecoveryService.swift
+++ b/Network/Service/Auth/AccountRecoveryService.swift
@@ -21,6 +21,9 @@ protocol AccountRecoveryService {
     
     /// 비밀번호 초기화
     func resetPassword(password: String) async throws -> PasswordResetResponse
+    
+    // 비밀번호 초기화에 필요한 resetToken 저장
+    func setResetToken(resetToken: String)
 }
 
 final class AccountRecoveryServiceImpl: AccountRecoveryService {
@@ -28,6 +31,7 @@ final class AccountRecoveryServiceImpl: AccountRecoveryService {
     // MARK: - Properties
     
     private let network: Network
+    private var resetToken: String = ""
     
     // MARK: - Initialize
     
@@ -53,7 +57,16 @@ final class AccountRecoveryServiceImpl: AccountRecoveryService {
     }
     
     func resetPassword(password: String) async throws -> PasswordResetResponse {
-        let request = PasswordResetRequest(password: password)
+        if resetToken.isEmpty {
+            print("잘못된 resetToken 입니다.")
+            throw NetworkError.unknownError
+        }
+        
+        let request = PasswordResetRequest(password: password, resetToken: resetToken)
         return try await network.send(request)
+    }
+    
+    func setResetToken(resetToken: String) {
+        self.resetToken = resetToken
     }
 }

--- a/QRIZ/Feature/FindAccount/ViewModel/FindPasswordVerificationViewModel.swift
+++ b/QRIZ/Feature/FindAccount/ViewModel/FindPasswordVerificationViewModel.swift
@@ -63,7 +63,8 @@ final class FindPasswordVerificationViewModel: EmailVerificationViewModel {
     override func verifyCode(email: String, authNumber: String) {
         Task {
             do {
-                _ = try await accountRecoveryService.verifyPasswordReset(email: email, authNumber: authNumber)
+                let response = try await accountRecoveryService.verifyPasswordReset(email: email, authNumber: authNumber)
+                accountRecoveryService.setResetToken(resetToken: response.data.resetToken)
                 outputSubject.send(.codeVerificationSuccess)
                 countdownTimer.stop()
             } catch {

--- a/QRIZ/Feature/MyPage/MyPageCoordinator.swift
+++ b/QRIZ/Feature/MyPage/MyPageCoordinator.swift
@@ -11,7 +11,7 @@ import UIKit
 protocol MyPageCoordinator: Coordinator {
     var delegate: MyPageCoordinatorDelegate? { get set }
     func showSettingsView()
-    func showChangePasswordView()
+//    func showChangePasswordView()
     func showFindPassword()
     func showResetAlert(confirm: @escaping () -> Void)
     func showExamSelectionSheet()
@@ -72,12 +72,12 @@ final class MyPageCoordinatorImpl: MyPageCoordinator {
         navigationController?.pushViewController(vc, animated: true)
     }
     
-    func showChangePasswordView() {
-        let viewModel = ChangePasswordViewModel(myPageService: myPageService)
-        let vc = ChangePasswordViewController(viewModel: viewModel)
-        vc.coordinator = self
-        navigationController?.pushViewController(vc, animated: true)
-    }
+//    func showChangePasswordView() {
+//        let viewModel = ChangePasswordViewModel(myPageService: myPageService)
+//        let vc = ChangePasswordViewController(viewModel: viewModel)
+//        vc.coordinator = self
+//        navigationController?.pushViewController(vc, animated: true)
+//    }
     
     func showFindPassword() {
         guard let navi = navigationController else { return }

--- a/QRIZ/Feature/MyPage/ViewController/SettingsViewController.swift
+++ b/QRIZ/Feature/MyPage/ViewController/SettingsViewController.swift
@@ -78,7 +78,7 @@ final class SettingsViewController: UIViewController {
                 rootView.profileHeaderView.configure(name: userName, email: email)
                 
             case .navigateToResetPassword:
-                self.coordinator?.showChangePasswordView()
+                self.coordinator?.showFindPassword()
                 
             case .showLogoutAlert:
                 self.coordinator?.showLogoutAlert()


### PR DESCRIPTION
## 🛠️ Task

- 마이페이지 비밀번호 재설정 코디네이터 로직 수정
- 변경된 비밀번호 재설정 request, response에 해당하는 resetToken 추가

## 🌱 PR Point

- resetToken을 Input / Output 패턴에 맞게 제공해서 VM과 Coordinator가 인자로써 주고받을 수 있도록 구현하고자 하였으나,
AccountRecovery 공통으로 상속받는 VM이 존재하기 때문에, 결합도가 높아지는 문제가 있습니다.
(b/c 인증코드 성공 시 바로 재설정 뷰로 넘어가는 것이 아니라, 따로 버튼을 누르는 경우에 다음 뷰의 VM으로 전달되어야하기 때문)

- 또한, 토큰 자체가 전반적인 로직과 관련있다기보다는 network 계층에만 필요하기 때문에, service 차원에서 사용할 수 있도록 구현했습니다.
(인증 성공 여부에 따라 UI 활성화되는 기존 로직과는 무관)

- resetToken을 public property로 접근하는 것보다는 private 으로 선언하고 setResetToken을 통해 저장할 수 있도록 구현함으로써, 저장하는 행위를 좀 더 명확하게 표현했습니다.

- 추후에 BE의 확장성을 고려하여 기존의 ChangePasswordVC, ChangePasswordVM 등을 제거하기보단,
유지하면서도 Coordinator 내부에서 주석처리 및 SettingsVC에서의 bind 메서드 내부의 호출되는 코디네이터 메서드를 수정했습니다.

```swift
case .navigateToResetPassword:
                self.coordinator?.showFindPassword()
```

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |

## 📮 Issue 번호
- resolved: #79 
