### PR TITLE
FEAT: 오답노트 디테일 뷰 구현 (1.0.2)

### DIFF
--- a/Network/DTOs/Daily/DailyResultDetailRequest.swift
+++ b/Network/DTOs/Daily/DailyResultDetailRequest.swift
@@ -43,7 +43,7 @@ struct DailyResultDetail: Decodable {
     let skillName: String
     let questionText: String
     let questionNum: Int
-    let description: String
+    let description: String?
     let option1: String
     let option2: String
     let option3: String

--- a/Network/DTOs/Daily/DailyResultDetailRequest.swift
+++ b/Network/DTOs/Daily/DailyResultDetailRequest.swift
@@ -1,0 +1,59 @@
+//
+//  DailyResultDetailRequest.swift
+//  QRIZ
+//
+//  Created by Claude on 1/2/26.
+//
+
+import Foundation
+
+struct DailyResultDetailRequest: Request {
+    typealias Response = DailyResultDetailResponse
+
+    let method: HTTPMethod = .get
+    private let accessToken: String
+    private let dayNumber: Int
+    private let questionId: Int
+
+    var path: String {
+        "/api/v1/daily/result/\(dayNumber)/\(questionId)"
+    }
+
+    var headers: HTTPHeader {
+        [
+            HTTPHeaderField.authorization.rawValue: accessToken
+        ]
+    }
+
+    init(accessToken: String, dayNumber: Int, questionId: Int) {
+        self.accessToken = accessToken
+        self.dayNumber = dayNumber
+        self.questionId = questionId
+    }
+}
+
+
+struct DailyResultDetailResponse: Decodable {
+    let code: Int
+    let msg: String
+    let data: DailyResultDetail
+}
+
+struct DailyResultDetail: Decodable {
+    let skillName: String
+    let questionText: String
+    let questionNum: Int
+    let description: String
+    let option1: String
+    let option2: String
+    let option3: String
+    let option4: String
+    let answer: Int
+    let solution: String
+    let checked: Int?
+    let correction: Bool
+    let testInfo: String
+    let skillId: Int
+    let title: String
+    let keyConcepts: String
+}

--- a/Network/Service/Daily/DailyService.swift
+++ b/Network/Service/Daily/DailyService.swift
@@ -21,6 +21,8 @@ protocol DailyService {
     func getDailyPlan() async throws -> DailyPlanResponse
     
     func resetPlan() async throws -> DailyResetResponse
+
+    func getDailyResultDetail(dayNumber: Int, questionId: Int) async throws -> DailyResultDetailResponse
 }
 
 final class DailyServiceImpl: DailyService {
@@ -70,7 +72,16 @@ final class DailyServiceImpl: DailyService {
         let request = DailyResetRequest(accessToken: getAccessToken())
         return try await network.send(request)
     }
-    
+
+    func getDailyResultDetail(dayNumber: Int, questionId: Int) async throws -> DailyResultDetailResponse {
+        let request = DailyResultDetailRequest(
+            accessToken: getAccessToken(),
+            dayNumber: dayNumber,
+            questionId: questionId
+        )
+        return try await network.send(request)
+    }
+
     private func getAccessToken() -> String {
         let accessToken = keychainManager.retrieveToken(forKey: HTTPHeaderField.accessToken.rawValue) ?? ""
         return accessToken

--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -58,6 +58,11 @@
 		B1510DBB2E11B2E800657506 /* DashedLineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1510DBA2E11B2E800657506 /* DashedLineView.swift */; };
 		B15188622D76D29B000EFE41 /* EmailSendRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15188612D76D29B000EFE41 /* EmailSendRequest.swift */; };
 		B15188662D782CCE000EFE41 /* SignUpCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15188652D782CCE000EFE41 /* SignUpCoordinator.swift */; };
+		B1561C492F0541E300DEFC00 /* ProblemResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1561C482F0541E300DEFC00 /* ProblemResultView.swift */; };
+		B1561C4B2F06584800DEFC00 /* ProblemSolutionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1561C4A2F06584800DEFC00 /* ProblemSolutionView.swift */; };
+		B1561C4F2F06D37800DEFC00 /* ProblemKeyConceptsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1561C4E2F06D37800DEFC00 /* ProblemKeyConceptsView.swift */; };
+		B1561C512F07E09400DEFC00 /* DailyResultDetailRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1561C502F07E09400DEFC00 /* DailyResultDetailRequest.swift */; };
+		B1561C532F0816DE00DEFC00 /* ProblemDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1561C522F0816DE00DEFC00 /* ProblemDetailViewModel.swift */; };
 		B16288182D2CDB85008057D0 /* NameInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B16288172D2CDB85008057D0 /* NameInputViewModel.swift */; };
 		B162881C2D2CFC63008057D0 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B162881B2D2CFC63008057D0 /* UIView+.swift */; };
 		B162881E2D2D6624008057D0 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B162881D2D2D6624008057D0 /* UIViewController+.swift */; };
@@ -132,8 +137,12 @@
 		B1C8B90C2EFF2A6500C3E709 /* NavigationGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C8B90B2EFF2A6500C3E709 /* NavigationGuard.swift */; };
 		B1C8BCC12F03093800C3E709 /* ProblemHeaderData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C8BCBF2F03093800C3E709 /* ProblemHeaderData.swift */; };
 		B1C8BCC92F03096C00C3E709 /* ProblemHeaderCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C8BCC32F03096C00C3E709 /* ProblemHeaderCardView.swift */; };
-		B1C8BCCA2F03096C00C3E709 /* ProblemExplanationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C8BCC52F03096C00C3E709 /* ProblemExplanationViewController.swift */; };
-		B1C8BCCB2F03096C00C3E709 /* ProblemExplanationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C8BCC22F03096C00C3E709 /* ProblemExplanationView.swift */; };
+		B1C8BCCA2F03096C00C3E709 /* ProblemDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C8BCC52F03096C00C3E709 /* ProblemDetailViewController.swift */; };
+		B1C8BCCB2F03096C00C3E709 /* ProblemDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C8BCC22F03096C00C3E709 /* ProblemDetailView.swift */; };
+		B1C8BCCF2F04274600C3E709 /* MockDailyResultData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C8BCCD2F04274600C3E709 /* MockDailyResultData.swift */; };
+		B1C8BCD12F04316600C3E709 /* ProblemQuestionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C8BCD02F04316600C3E709 /* ProblemQuestionData.swift */; };
+		B1C8BCD42F0431E900C3E709 /* ProblemOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C8BCD22F0431E900C3E709 /* ProblemOptionView.swift */; };
+		B1C8BCD52F0431E900C3E709 /* ProblemQuestionSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C8BCD32F0431E900C3E709 /* ProblemQuestionSectionView.swift */; };
 		B1D813712D6E0C1F00A9D447 /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D813702D6E0C1F00A9D447 /* HomeCoordinator.swift */; };
 		B1D813732D6E0CB200A9D447 /* ConceptBookCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D813722D6E0CB200A9D447 /* ConceptBookCoordinator.swift */; };
 		B1D813752D6E0CC900A9D447 /* MistakeNoteCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D813742D6E0CC900A9D447 /* MistakeNoteCoordinator.swift */; };
@@ -348,6 +357,11 @@
 		B1510DBA2E11B2E800657506 /* DashedLineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashedLineView.swift; sourceTree = "<group>"; };
 		B15188612D76D29B000EFE41 /* EmailSendRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailSendRequest.swift; sourceTree = "<group>"; };
 		B15188652D782CCE000EFE41 /* SignUpCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpCoordinator.swift; sourceTree = "<group>"; };
+		B1561C482F0541E300DEFC00 /* ProblemResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemResultView.swift; sourceTree = "<group>"; };
+		B1561C4A2F06584800DEFC00 /* ProblemSolutionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemSolutionView.swift; sourceTree = "<group>"; };
+		B1561C4E2F06D37800DEFC00 /* ProblemKeyConceptsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemKeyConceptsView.swift; sourceTree = "<group>"; };
+		B1561C502F07E09400DEFC00 /* DailyResultDetailRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyResultDetailRequest.swift; sourceTree = "<group>"; };
+		B1561C522F0816DE00DEFC00 /* ProblemDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemDetailViewModel.swift; sourceTree = "<group>"; };
 		B16288172D2CDB85008057D0 /* NameInputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameInputViewModel.swift; sourceTree = "<group>"; };
 		B162881B2D2CFC63008057D0 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		B162881D2D2D6624008057D0 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
@@ -419,9 +433,13 @@
 		B19C4FC42D6C226500CD008A /* TabBarCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarCoordinator.swift; sourceTree = "<group>"; };
 		B1C8B90B2EFF2A6500C3E709 /* NavigationGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationGuard.swift; sourceTree = "<group>"; };
 		B1C8BCBF2F03093800C3E709 /* ProblemHeaderData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemHeaderData.swift; sourceTree = "<group>"; };
-		B1C8BCC22F03096C00C3E709 /* ProblemExplanationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemExplanationView.swift; sourceTree = "<group>"; };
+		B1C8BCC22F03096C00C3E709 /* ProblemDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemDetailView.swift; sourceTree = "<group>"; };
 		B1C8BCC32F03096C00C3E709 /* ProblemHeaderCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemHeaderCardView.swift; sourceTree = "<group>"; };
-		B1C8BCC52F03096C00C3E709 /* ProblemExplanationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemExplanationViewController.swift; sourceTree = "<group>"; };
+		B1C8BCC52F03096C00C3E709 /* ProblemDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemDetailViewController.swift; sourceTree = "<group>"; };
+		B1C8BCCD2F04274600C3E709 /* MockDailyResultData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDailyResultData.swift; sourceTree = "<group>"; };
+		B1C8BCD02F04316600C3E709 /* ProblemQuestionData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemQuestionData.swift; sourceTree = "<group>"; };
+		B1C8BCD22F0431E900C3E709 /* ProblemOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemOptionView.swift; sourceTree = "<group>"; };
+		B1C8BCD32F0431E900C3E709 /* ProblemQuestionSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemQuestionSectionView.swift; sourceTree = "<group>"; };
 		B1D813702D6E0C1F00A9D447 /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
 		B1D813722D6E0CB200A9D447 /* ConceptBookCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConceptBookCoordinator.swift; sourceTree = "<group>"; };
 		B1D813742D6E0CC900A9D447 /* MistakeNoteCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MistakeNoteCoordinator.swift; sourceTree = "<group>"; };
@@ -1135,19 +1153,26 @@
 			path = TabBar;
 			sourceTree = "<group>";
 		};
-		B1C8BCC02F03093800C3E709 /* ProblemExplanation */ = {
+		B1C8BCC02F03093800C3E709 /* ProblemDetail */ = {
 			isa = PBXGroup;
 			children = (
+				B1C8BCD02F04316600C3E709 /* ProblemQuestionData.swift */,
 				B1C8BCBF2F03093800C3E709 /* ProblemHeaderData.swift */,
+				B1C8BCCD2F04274600C3E709 /* MockDailyResultData.swift */,
 			);
-			path = ProblemExplanation;
+			path = ProblemDetail;
 			sourceTree = "<group>";
 		};
 		B1C8BCC42F03096C00C3E709 /* View */ = {
 			isa = PBXGroup;
 			children = (
-				B1C8BCC22F03096C00C3E709 /* ProblemExplanationView.swift */,
 				B1C8BCC32F03096C00C3E709 /* ProblemHeaderCardView.swift */,
+				B1C8BCD22F0431E900C3E709 /* ProblemOptionView.swift */,
+				B1C8BCD32F0431E900C3E709 /* ProblemQuestionSectionView.swift */,
+				B1561C482F0541E300DEFC00 /* ProblemResultView.swift */,
+				B1561C4A2F06584800DEFC00 /* ProblemSolutionView.swift */,
+				B1561C4E2F06D37800DEFC00 /* ProblemKeyConceptsView.swift */,
+				B1C8BCC22F03096C00C3E709 /* ProblemDetailView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1155,7 +1180,7 @@
 		B1C8BCC62F03096C00C3E709 /* ViewController */ = {
 			isa = PBXGroup;
 			children = (
-				B1C8BCC52F03096C00C3E709 /* ProblemExplanationViewController.swift */,
+				B1C8BCC52F03096C00C3E709 /* ProblemDetailViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -1163,6 +1188,7 @@
 		B1C8BCC72F03096C00C3E709 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
+				B1561C522F0816DE00DEFC00 /* ProblemDetailViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1619,6 +1645,7 @@
 				E25854E62DC3A4AF00AE174C /* DailyResultRequest.swift */,
 				E2DE756F2DD84C5B0056D42C /* DailyWeeklyScoreRequest.swift */,
 				B1138AFA2DFD813D004258CA /* DailyResetRequest.swift */,
+				B1561C502F07E09400DEFC00 /* DailyResultDetailRequest.swift */,
 			);
 			path = Daily;
 			sourceTree = "<group>";
@@ -1743,7 +1770,7 @@
 		E29BF8532D117CD5006DC6D0 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				B1C8BCC02F03093800C3E709 /* ProblemExplanation */,
+				B1C8BCC02F03093800C3E709 /* ProblemDetail */,
 				B13048972DE1E6370036EBE2 /* Home */,
 				E24907D62D61A26D004D6E61 /* DailyLearnModel */,
 				E29BF86B2D16894C006DC6D0 /* TestModel */,
@@ -2193,6 +2220,8 @@
 				B1C8B90C2EFF2A6500C3E709 /* NavigationGuard.swift in Sources */,
 				B1151FD72E64A1DD00C1F720 /* SocialLoginType.swift in Sources */,
 				E25F94D12D0CB74700BA765F /* OnboardingButton.swift in Sources */,
+				B1C8BCD42F0431E900C3E709 /* ProblemOptionView.swift in Sources */,
+				B1C8BCD52F0431E900C3E709 /* ProblemQuestionSectionView.swift in Sources */,
 				E25AB8082DC0CB2C00E7A7E3 /* DailySubmitRequest.swift in Sources */,
 				E25907CC2D8328FC0093121C /* PreviewResultView.swift in Sources */,
 				B16288222D2E3CAB008057D0 /* UINavigationBar+.swift in Sources */,
@@ -2204,10 +2233,12 @@
 				B168B7602D28073C0000F32E /* SignUpHeaderView.swift in Sources */,
 				B16774D52D8959B3001820F3 /* FindIDRequest.swift in Sources */,
 				B168B7712D28276F0000F32E /* IDInputView.swift in Sources */,
+				B1561C532F0816DE00DEFC00 /* ProblemDetailViewModel.swift in Sources */,
 				E25F335F2DAFC222002347D4 /* DailyResultScoreView.swift in Sources */,
 				B1510DBB2E11B2E800657506 /* DashedLineView.swift in Sources */,
 				B19C4F6D2D5262D900CD008A /* Combine+.swift in Sources */,
 				B18F452C2D4D5CF00030F7DB /* ResetPasswordViewModel.swift in Sources */,
+				B1561C4B2F06584800DEFC00 /* ProblemSolutionView.swift in Sources */,
 				E22341AD2DD4C35D00A67D04 /* ExamSummaryViewController.swift in Sources */,
 				B17D6AD92D97FE450023FCA5 /* LoginService.swift in Sources */,
 				B1510DB22E0A92C400657506 /* DailyPlanRequest.swift in Sources */,
@@ -2250,6 +2281,7 @@
 				E29CCD2F2D29855B004AA30A /* TestTimeLabel.swift in Sources */,
 				B168B7732D2846C80000F32E /* PasswordInputViewController.swift in Sources */,
 				E2A6C07E2DBB58220059F960 /* PreviewTestListRequest.swift in Sources */,
+				B1C8BCD12F04316600C3E709 /* ProblemQuestionData.swift in Sources */,
 				B1138AFB2DFD813D004258CA /* DailyResetRequest.swift in Sources */,
 				B16774DF2D89F783001820F3 /* PasswordResetRequest.swift in Sources */,
 				B18F45182D3A528B0030F7DB /* FindIDViewModel.swift in Sources */,
@@ -2277,6 +2309,7 @@
 				541878542D0E21620089F478 /* HTTPMethod.swift in Sources */,
 				E211AE032DE47D4D00AB24FE /* ExamResultScoreView.swift in Sources */,
 				B11EC5AB2EC1B11700DCE8C5 /* RefreshTokenRequest.swift in Sources */,
+				B1C8BCCF2F04274600C3E709 /* MockDailyResultData.swift in Sources */,
 				B18F45222D4645EC0030F7DB /* VerificationInputView.swift in Sources */,
 				E2908E622DAF5B8400B8E81B /* Int+.swift in Sources */,
 				B18CDF6F2DD2FF9500DD361A /* TermsAgreementModalViewController.swift in Sources */,
@@ -2362,8 +2395,8 @@
 				E29CCD2D2D29855B004AA30A /* TestPageIndicatorLabel.swift in Sources */,
 				E2939CA32D9D605C00F7E704 /* TestContentsView.swift in Sources */,
 				B1C8BCC92F03096C00C3E709 /* ProblemHeaderCardView.swift in Sources */,
-				B1C8BCCA2F03096C00C3E709 /* ProblemExplanationViewController.swift in Sources */,
-				B1C8BCCB2F03096C00C3E709 /* ProblemExplanationView.swift in Sources */,
+				B1C8BCCA2F03096C00C3E709 /* ProblemDetailViewController.swift in Sources */,
+				B1C8BCCB2F03096C00C3E709 /* ProblemDetailView.swift in Sources */,
 				E24CB16A2DB5373900D88451 /* ResultDetailScoreView.swift in Sources */,
 				E25856DE2D0DADD300355667 /* BeginOnboardingViewModel.swift in Sources */,
 				E27843212DDE13B600E9AD07 /* ExamTestViewController.swift in Sources */,
@@ -2377,6 +2410,7 @@
 				B151082B2DFFEA8C00657506 /* MyPageViewController.swift in Sources */,
 				B151082C2DFFEA8C00657506 /* SettingsViewController.swift in Sources */,
 				E217C36B2D9BF0C30095A3D8 /* DailyResultViewController.swift in Sources */,
+				B1561C4F2F06D37800DEFC00 /* ProblemKeyConceptsView.swift in Sources */,
 				B190A2E42DC0E023008FDE86 /* RoundBoxLabel.swift in Sources */,
 				E24907D32D619F39004D6E61 /* DailyLearnViewModel.swift in Sources */,
 				E211AE012DE47B2900AB24FE /* ExamResultView.swift in Sources */,
@@ -2403,6 +2437,7 @@
 				B15108432DFFEB2700657506 /* SettingsOptionView.swift in Sources */,
 				B15108442DFFEB2700657506 /* DeleteAccountMainView.swift in Sources */,
 				B15108452DFFEB2700657506 /* MyPageMainView.swift in Sources */,
+				B1561C512F07E09400DEFC00 /* DailyResultDetailRequest.swift in Sources */,
 				B15108462DFFEB2700657506 /* SettingsMainView.swift in Sources */,
 				B16288182D2CDB85008057D0 /* NameInputViewModel.swift in Sources */,
 				E28A93852D945F95006A15DB /* StudyContentCell.swift in Sources */,
@@ -2421,6 +2456,7 @@
 				B168B7752D2846DD0000F32E /* PasswordInputMainView.swift in Sources */,
 				B16288202D2E2595008057D0 /* SignUpVerificationViewModel.swift in Sources */,
 				B17FE3082D27F87E002EC7D7 /* String+.swift in Sources */,
+				B1561C492F0541E300DEFC00 /* ProblemResultView.swift in Sources */,
 				B19C4FA92D5D182600CD008A /* EmailVerificationViewModel.swift in Sources */,
 				B168B7612D28073C0000F32E /* SingleInputView.swift in Sources */,
 				54C7A3162D14A5A6001175D9 /* LoginLogoView.swift in Sources */,

--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -130,6 +130,10 @@
 		B1B0BBBC2E769F510024F230 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = B1B0BBBB2E769F510024F230 /* GoogleSignIn */; };
 		B1B0BBBE2E769F510024F230 /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = B1B0BBBD2E769F510024F230 /* GoogleSignInSwift */; };
 		B1C8B90C2EFF2A6500C3E709 /* NavigationGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C8B90B2EFF2A6500C3E709 /* NavigationGuard.swift */; };
+		B1C8BCC12F03093800C3E709 /* ProblemHeaderData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C8BCBF2F03093800C3E709 /* ProblemHeaderData.swift */; };
+		B1C8BCC92F03096C00C3E709 /* ProblemHeaderCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C8BCC32F03096C00C3E709 /* ProblemHeaderCardView.swift */; };
+		B1C8BCCA2F03096C00C3E709 /* ProblemExplanationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C8BCC52F03096C00C3E709 /* ProblemExplanationViewController.swift */; };
+		B1C8BCCB2F03096C00C3E709 /* ProblemExplanationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C8BCC22F03096C00C3E709 /* ProblemExplanationView.swift */; };
 		B1D813712D6E0C1F00A9D447 /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D813702D6E0C1F00A9D447 /* HomeCoordinator.swift */; };
 		B1D813732D6E0CB200A9D447 /* ConceptBookCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D813722D6E0CB200A9D447 /* ConceptBookCoordinator.swift */; };
 		B1D813752D6E0CC900A9D447 /* MistakeNoteCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D813742D6E0CC900A9D447 /* MistakeNoteCoordinator.swift */; };
@@ -414,6 +418,10 @@
 		B19C4FBE2D6B6E3400CD008A /* MistakeNoteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MistakeNoteViewController.swift; sourceTree = "<group>"; };
 		B19C4FC42D6C226500CD008A /* TabBarCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarCoordinator.swift; sourceTree = "<group>"; };
 		B1C8B90B2EFF2A6500C3E709 /* NavigationGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationGuard.swift; sourceTree = "<group>"; };
+		B1C8BCBF2F03093800C3E709 /* ProblemHeaderData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemHeaderData.swift; sourceTree = "<group>"; };
+		B1C8BCC22F03096C00C3E709 /* ProblemExplanationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemExplanationView.swift; sourceTree = "<group>"; };
+		B1C8BCC32F03096C00C3E709 /* ProblemHeaderCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemHeaderCardView.swift; sourceTree = "<group>"; };
+		B1C8BCC52F03096C00C3E709 /* ProblemExplanationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemExplanationViewController.swift; sourceTree = "<group>"; };
 		B1D813702D6E0C1F00A9D447 /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
 		B1D813722D6E0CB200A9D447 /* ConceptBookCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConceptBookCoordinator.swift; sourceTree = "<group>"; };
 		B1D813742D6E0CC900A9D447 /* MistakeNoteCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MistakeNoteCoordinator.swift; sourceTree = "<group>"; };
@@ -1114,6 +1122,7 @@
 			children = (
 				B19C4FBE2D6B6E3400CD008A /* MistakeNoteViewController.swift */,
 				B1D813742D6E0CC900A9D447 /* MistakeNoteCoordinator.swift */,
+				B1C8BCC82F03096C00C3E709 /* ProblemExplanation */,
 			);
 			path = MistakeNote;
 			sourceTree = "<group>";
@@ -1124,6 +1133,48 @@
 				B19C4FC42D6C226500CD008A /* TabBarCoordinator.swift */,
 			);
 			path = TabBar;
+			sourceTree = "<group>";
+		};
+		B1C8BCC02F03093800C3E709 /* ProblemExplanation */ = {
+			isa = PBXGroup;
+			children = (
+				B1C8BCBF2F03093800C3E709 /* ProblemHeaderData.swift */,
+			);
+			path = ProblemExplanation;
+			sourceTree = "<group>";
+		};
+		B1C8BCC42F03096C00C3E709 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				B1C8BCC22F03096C00C3E709 /* ProblemExplanationView.swift */,
+				B1C8BCC32F03096C00C3E709 /* ProblemHeaderCardView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		B1C8BCC62F03096C00C3E709 /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				B1C8BCC52F03096C00C3E709 /* ProblemExplanationViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
+		B1C8BCC72F03096C00C3E709 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		B1C8BCC82F03096C00C3E709 /* ProblemExplanation */ = {
+			isa = PBXGroup;
+			children = (
+				B1C8BCC42F03096C00C3E709 /* View */,
+				B1C8BCC62F03096C00C3E709 /* ViewController */,
+				B1C8BCC72F03096C00C3E709 /* ViewModel */,
+			);
+			path = ProblemExplanation;
 			sourceTree = "<group>";
 		};
 		B1D813782D768D3D00A9D447 /* Coordinator */ = {
@@ -1692,6 +1743,7 @@
 		E29BF8532D117CD5006DC6D0 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				B1C8BCC02F03093800C3E709 /* ProblemExplanation */,
 				B13048972DE1E6370036EBE2 /* Home */,
 				E24907D62D61A26D004D6E61 /* DailyLearnModel */,
 				E29BF86B2D16894C006DC6D0 /* TestModel */,
@@ -2309,10 +2361,14 @@
 				B18CDF712DD3001B00DD361A /* TermsAgreementModalMainView.swift in Sources */,
 				E29CCD2D2D29855B004AA30A /* TestPageIndicatorLabel.swift in Sources */,
 				E2939CA32D9D605C00F7E704 /* TestContentsView.swift in Sources */,
+				B1C8BCC92F03096C00C3E709 /* ProblemHeaderCardView.swift in Sources */,
+				B1C8BCCA2F03096C00C3E709 /* ProblemExplanationViewController.swift in Sources */,
+				B1C8BCCB2F03096C00C3E709 /* ProblemExplanationView.swift in Sources */,
 				E24CB16A2DB5373900D88451 /* ResultDetailScoreView.swift in Sources */,
 				E25856DE2D0DADD300355667 /* BeginOnboardingViewModel.swift in Sources */,
 				E27843212DDE13B600E9AD07 /* ExamTestViewController.swift in Sources */,
 				B1D9A0E72D3686BA00E84934 /* CountdownTimer.swift in Sources */,
+				B1C8BCC12F03093800C3E709 /* ProblemHeaderData.swift in Sources */,
 				E2C1016B2DF2E10200C3512E /* OnboardingCoordinator.swift in Sources */,
 				B18F45102D3997280030F7DB /* FindAccountHeaderView.swift in Sources */,
 				E29BF8552D117CF1006DC6D0 /* SurveyCheckList.swift in Sources */,

--- a/QRIZ/Feature/Daily/DailyCoordinator.swift
+++ b/QRIZ/Feature/Daily/DailyCoordinator.swift
@@ -117,13 +117,8 @@ final class DailyCoordinatorImpl: DailyCoordinator, NavigationGuard {
                 questionId: questionId,
                 dayNumber: day
             )
-            let vc = ProblemDetailViewController(
-                viewModel: viewModel,
-                onNavigateToConcept: { [weak self] in
-                    guard let self = self else { return }
-                    self.delegate?.moveFromDailyToConcept(self)
-                }
-            )
+            let vc = ProblemDetailViewController(viewModel: viewModel)
+            vc.coordinator = self
             navigationController.pushViewController(vc, animated: true)
         }
     }
@@ -134,5 +129,17 @@ final class DailyCoordinatorImpl: DailyCoordinator, NavigationGuard {
             _ = self.navigationController.popToViewController(dailyLearnVC, animated: true)
             dailyLearnVM.reloadData()
         }
+    }
+}
+
+// MARK: - ProblemDetailCoordinating
+
+extension DailyCoordinatorImpl: ProblemDetailCoordinating {
+    func navigateToConceptTab() {
+        delegate?.moveFromDailyToConcept(self)
+    }
+
+    func navigateToConcept(chapter: Chapter, conceptItem: ConceptItem) {
+        showConcept(chapter: chapter, conceptItem: conceptItem)
     }
 }

--- a/QRIZ/Feature/Daily/DailyCoordinator.swift
+++ b/QRIZ/Feature/Daily/DailyCoordinator.swift
@@ -15,6 +15,7 @@ protocol DailyCoordinator: Coordinator {
     func showDailyTest()
     func showDailyResult()
     func showResultDetail(resultDetailData: ResultDetailData)
+    func showProblemExplanation(questionId: Int)
     func quitDaily()
 }
 
@@ -108,7 +109,19 @@ final class DailyCoordinatorImpl: DailyCoordinator, NavigationGuard {
             navigationController.pushViewController(vc, animated: true)
         }
     }
-    
+
+    func showProblemExplanation(questionId: Int) {
+        guardNavigation {
+            let viewModel = ProblemDetailViewModel(
+                service: service,
+                questionId: questionId,
+                dayNumber: day
+            )
+            let vc = ProblemDetailViewController(viewModel: viewModel)
+            navigationController.pushViewController(vc, animated: true)
+        }
+    }
+
     /// Daily 내부 테스트나 결과에서 DailyLearn으로 이동하는 메서드
     func quitDaily() {
         if let dailyLearnVC = dailyLearnViewController, let dailyLearnVM = dailyLearnViewModel {

--- a/QRIZ/Feature/Daily/DailyCoordinator.swift
+++ b/QRIZ/Feature/Daily/DailyCoordinator.swift
@@ -74,12 +74,6 @@ final class DailyCoordinatorImpl: DailyCoordinator, NavigationGuard {
         guardNavigation {
             let vm = ConceptPDFViewModel(chapter: chapter, conceptItem: conceptItem)
             let vc = ConceptPDFViewController(conceptPDFViewModel: vm)
-            let appearance = UINavigationBar.defaultBackButtonStyle()
-
-            navigationController.navigationBar.standardAppearance = appearance
-            navigationController.navigationBar.compactAppearance = appearance
-            navigationController.navigationBar.scrollEdgeAppearance = appearance
-
             navigationController.pushViewController(vc, animated: true)
         }
     }

--- a/QRIZ/Feature/Daily/DailyCoordinator.swift
+++ b/QRIZ/Feature/Daily/DailyCoordinator.swift
@@ -117,7 +117,13 @@ final class DailyCoordinatorImpl: DailyCoordinator, NavigationGuard {
                 questionId: questionId,
                 dayNumber: day
             )
-            let vc = ProblemDetailViewController(viewModel: viewModel)
+            let vc = ProblemDetailViewController(
+                viewModel: viewModel,
+                onNavigateToConcept: { [weak self] in
+                    guard let self = self else { return }
+                    self.delegate?.moveFromDailyToConcept(self)
+                }
+            )
             navigationController.pushViewController(vc, animated: true)
         }
     }

--- a/QRIZ/Feature/Daily/DailyResult/View/DailyResultView.swift
+++ b/QRIZ/Feature/Daily/DailyResult/View/DailyResultView.swift
@@ -9,20 +9,24 @@ import SwiftUI
 import Combine
 
 struct DailyResultView: View {
-    
+
     @ObservedObject var resultScoresData: ResultScoresData
     @ObservedObject var resultGradeListData: ResultGradeListData
     @ObservedObject var resultDetailData: ResultDetailData
     @State var dailyLearnType: DailyLearnType
-    
+
     private let contentsInput: PassthroughSubject<Void, Never> = .init()
     private let footerInput: PassthroughSubject<Void, Never> = .init()
-    
+    private let problemTapInput: PassthroughSubject<Int, Never> = .init()
+
     var resultDetailTappedPublisher: AnyPublisher<Void, Never> {
         contentsInput.eraseToAnyPublisher()
     }
     var conceptTappedPublisher: AnyPublisher<Void, Never> {
         footerInput.eraseToAnyPublisher()
+    }
+    var problemTappedPublisher: AnyPublisher<Int, Never> {
+        problemTapInput.eraseToAnyPublisher()
     }
     
     var body: some View {
@@ -33,7 +37,10 @@ struct DailyResultView: View {
                                      dailyLearnType: $dailyLearnType,
                                      input: contentsInput)
                 Spacer(minLength: 16)
-                TestResultGradesListView(resultGradeListData: resultGradeListData)
+                TestResultGradesListView(
+                    resultGradeListData: resultGradeListData,
+                    onProblemTap: problemTapInput
+                )
                 TestResultFooterView(resultScoresData: resultScoresData, input: footerInput)
             }
             .background(.customBlue50)

--- a/QRIZ/Feature/Daily/DailyResult/ViewController/DailyResultViewController.swift
+++ b/QRIZ/Feature/Daily/DailyResult/ViewController/DailyResultViewController.swift
@@ -23,8 +23,9 @@ final class DailyResultViewController: UIViewController {
     init(viewModel: DailyResultViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
+        self.hidesBottomBarWhenPushed = true
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("no initializer for coder: DailyResultViewController")
     }

--- a/QRIZ/Feature/Daily/DailyResult/ViewController/DailyResultViewController.swift
+++ b/QRIZ/Feature/Daily/DailyResult/ViewController/DailyResultViewController.swift
@@ -46,8 +46,11 @@ final class DailyResultViewController: UIViewController {
         let conceptTapped = dailyResultViewHostingController.rootView.conceptTappedPublisher.map {
             DailyResultViewModel.Input.moveToConceptButtonClicked
         }
-        
-        let mergedInput = input.merge(with: resultDetailTapped, conceptTapped)
+        let problemTapped = dailyResultViewHostingController.rootView.problemTappedPublisher.map {
+            DailyResultViewModel.Input.problemTapped(questionId: $0)
+        }
+
+        let mergedInput = input.merge(with: resultDetailTapped, conceptTapped, problemTapped)
         let output = viewModel.transform(input: mergedInput.eraseToAnyPublisher())
         output
             .receive(on: DispatchQueue.main)
@@ -65,11 +68,12 @@ final class DailyResultViewController: UIViewController {
                     if let coordinator = coordinator {
                         coordinator.delegate?.moveFromDailyToConcept(coordinator)
                     }
-                    
                 case .moveToDailyLearn:
                     coordinator?.quitDaily()
                 case .moveToResultDetail:
                     coordinator?.showResultDetail(resultDetailData: self.viewModel.resultDetailData)
+                case .showProblemDetail(let questionId):
+                    coordinator?.showProblemExplanation(questionId: questionId)
                 }
             }
             .store(in: &subscriptions)

--- a/QRIZ/Feature/Daily/DailyResult/ViewModel/DailyResultViewModel.swift
+++ b/QRIZ/Feature/Daily/DailyResult/ViewModel/DailyResultViewModel.swift
@@ -181,7 +181,13 @@ final class DailyResultViewModel {
     private func updateSubjectList(subjectResultList: [SubjectResult]) {
         subjectResultList.enumerated().forEach { [weak self] in
             guard let self = self else { return }
-            self.gradeResultList.append(GradeResult(id: $0 + 1, skillName: $1.detailType, question: $1.question, correction: $1.correction))
+            self.gradeResultList.append(GradeResult(
+                id: $0 + 1,
+                questionId: $1.questionId,
+                skillName: $1.detailType,
+                question: $1.question,
+                correction: $1.correction
+            ))
         }
     }
 }

--- a/QRIZ/Feature/Daily/DailyResult/ViewModel/DailyResultViewModel.swift
+++ b/QRIZ/Feature/Daily/DailyResult/ViewModel/DailyResultViewModel.swift
@@ -16,13 +16,15 @@ final class DailyResultViewModel {
         case cancelButtonClicked
         case moveToConceptButtonClicked
         case resultDetailButtonClicked
+        case problemTapped(questionId: Int)
     }
-    
+
     enum Output {
         case fetchFailed(isServerError: Bool)
         case moveToDailyLearn
         case moveToConcept
         case moveToResultDetail
+        case showProblemDetail(questionId: Int)
     }
     
     // MARK: - Properties
@@ -71,6 +73,8 @@ final class DailyResultViewModel {
                 if dailyTestType == .weekly {
                     output.send(.moveToResultDetail)
                 }
+            case .problemTapped(let questionId):
+                output.send(.showProblemDetail(questionId: questionId))
             }
         }
         .store(in: &subscriptions)

--- a/QRIZ/Feature/Exam/ExamResult/View/ExamResultView.swift
+++ b/QRIZ/Feature/Exam/ExamResult/View/ExamResultView.swift
@@ -9,20 +9,24 @@ import SwiftUI
 import Combine
 
 struct ExamResultView: View {
-    
+
     @ObservedObject var resultScoresData: ResultScoresData
     @ObservedObject var resultGradeListData: ResultGradeListData
     @ObservedObject var resultDetailData: ResultDetailData
     @ObservedObject var scoreGraphData: ScoreGraphData
-    
+
     private let contentsInput: PassthroughSubject<Void, Never> = .init()
     private let footerInput: PassthroughSubject<Void, Never> = .init()
-    
+    private let problemTapInput: PassthroughSubject<Int, Never> = .init()
+
     var resultDetailTappedPublisher: AnyPublisher<Void, Never> {
         contentsInput.eraseToAnyPublisher()
     }
     var conceptTappedPublisher: AnyPublisher<Void, Never> {
         footerInput.eraseToAnyPublisher()
+    }
+    var problemTappedPublisher: AnyPublisher<Int, Never> {
+        problemTapInput.eraseToAnyPublisher()
     }
     
     var body: some View {
@@ -39,8 +43,11 @@ struct ExamResultView: View {
                     Spacer(minLength: 16)
                 }
 
-                TestResultGradesListView(resultGradeListData: resultGradeListData)
-                
+                TestResultGradesListView(
+                    resultGradeListData: resultGradeListData,
+                    onProblemTap: problemTapInput
+                )
+
                 TestResultFooterView(resultScoresData: resultScoresData, input: footerInput)
             }
             .background(.customBlue50)

--- a/QRIZ/Feature/Exam/ExamResult/ViewModel/ExamResultViewModel.swift
+++ b/QRIZ/Feature/Exam/ExamResult/ViewModel/ExamResultViewModel.swift
@@ -96,6 +96,7 @@ final class ExamResultViewModel {
             guard let self = self else { return }
             self.gradeResultList.append(
                 GradeResult(id: $0 + 1,
+                            questionId: $1.questionId,
                             skillName: $1.skillName,
                             question: $1.question,
                             correction: $1.correction))

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemDetailView.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemDetailView.swift
@@ -9,20 +9,18 @@ import SwiftUI
 import Combine
 
 struct ProblemDetailView: View {
-
+    
     @ObservedObject var viewModel: ProblemDetailViewModel
     let learnButtonTapInput: PassthroughSubject<Void, Never>
     let conceptTapInput: PassthroughSubject<String, Never>
-
+    
     var body: some View {
-            ZStack {
-                Color.customBlue50.ignoresSafeArea()
-                contentGroup
-            }
-            .navigationTitle("오답노트")
-            .navigationBarTitleDisplayMode(.inline)
+        ZStack {
+            Color.customBlue50.ignoresSafeArea()
+            contentGroup
         }
     }
+}
 
 // MARK: - View Sections
 private extension ProblemDetailView {
@@ -37,14 +35,14 @@ private extension ProblemDetailView {
             mainScrollView(data: data)
         }
     }
-
+    
     func mainScrollView(data: DailyResultDetail) -> some View {
         ScrollView {
             VStack(spacing: 32) {
                 // 헤더 카드 (과목, 시험 정보 등)
                 ProblemHeaderCardView(data: data.headerData)
                     .padding(.bottom, 16)
-
+                
                 // 문제 섹션
                 VStack(spacing: 8) {
                     ProblemQuestionSectionView(data: data.questionData)
@@ -54,7 +52,7 @@ private extension ProblemDetailView {
                         userAnswer: data.checked ?? 0
                     )
                 }
-
+                
                 // 풀이 및 개념 섹션
                 VStack(spacing: 12) {
                     ProblemSolutionView(
@@ -68,7 +66,7 @@ private extension ProblemDetailView {
                         onConceptTap: conceptTapInput
                     )
                 }
-
+                
                 // 하단 액션 버튼
                 learnButton
             }
@@ -81,13 +79,13 @@ private extension ProblemDetailView {
 
 // MARK: - Subviews
 private extension ProblemDetailView {
-
+    
     var loadingView: some View {
         ProgressView()
             .scaleEffect(1.5)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
-
+    
     func errorView(message: String) -> some View {
         VStack(spacing: 20) {
             Text(message)
@@ -107,7 +105,7 @@ private extension ProblemDetailView {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
-
+    
     var learnButton: some View {
         Button(action: { learnButtonTapInput.send(()) }) {
             Text("학습하러 가기")

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemDetailView.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemDetailView.swift
@@ -9,54 +9,106 @@ import SwiftUI
 
 struct ProblemDetailView: View {
 
-    let data: DailyResultDetail
+    @ObservedObject var viewModel: ProblemDetailViewModel
 
     var body: some View {
+            ZStack {
+                Color.customBlue50.ignoresSafeArea()
+                contentGroup
+            }
+            .navigationTitle("오답노트")
+            .navigationBarTitleDisplayMode(.inline)
+            .onAppear {
+                Task { await viewModel.fetchProblemDetail() }
+            }
+        }
+    }
+
+// MARK: - View Sections
+private extension ProblemDetailView {
+    
+    @ViewBuilder
+    var contentGroup: some View {
+        if viewModel.isLoading {
+            loadingView
+        } else if let errorMessage = viewModel.errorMessage {
+            errorView(message: errorMessage)
+        } else if let data = viewModel.problemDetail {
+            mainScrollView(data: data)
+        }
+    }
+
+    func mainScrollView(data: DailyResultDetail) -> some View {
         ScrollView {
             VStack(spacing: 32) {
+                // 헤더 카드 (과목, 시험 정보 등)
                 ProblemHeaderCardView(data: data.headerData)
                     .padding(.bottom, 16)
 
+                // 문제 섹션
                 VStack(spacing: 8) {
-                    ProblemQuestionSectionView(data: data.questionData) // 문제 섹션
+                    ProblemQuestionSectionView(data: data.questionData)
                     
                     ProblemResultView(
                         correctAnswer: data.answer,
                         userAnswer: data.checked ?? 0
-                    ) // 정답 정보
+                    )
                 }
 
-                ProblemSolutionView(
-                    keyConcepts: data.keyConcepts,
-                    solutionText: data.solution
-                ) // 풀이 섹션
-                
-                ProblemKeyConceptsView(
-                    keyConcepts: data.keyConcepts,
-                    subject: data.title
-                ) // 활용된 개념 섹션
+                // 풀이 및 개념 섹션
+                VStack(spacing: 12) {
+                    ProblemSolutionView(
+                        keyConcepts: data.keyConcepts,
+                        solutionText: data.solution
+                    )
+                    
+                    ProblemKeyConceptsView(
+                        keyConcepts: data.keyConcepts,
+                        subject: data.title
+                    )
+                }
 
-                learnButton // 학습하러가기 버튼
+                // 하단 액션 버튼
+                learnButton
             }
             .padding(.horizontal, 18)
             .padding(.top, 16)
             .padding(.bottom, 12)
         }
-        .background(Color.customBlue50)
-        .navigationTitle("오답노트")
-        .navigationBarTitleDisplayMode(.inline)
     }
 }
 
 // MARK: - Subviews
-
 private extension ProblemDetailView {
 
-    /// 학습하러가기 버튼
+    var loadingView: some View {
+        ProgressView()
+            .scaleEffect(1.5)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    func errorView(message: String) -> some View {
+        VStack(spacing: 20) {
+            Text(message)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundColor(Color(.coolNeutral600))
+                .multilineTextAlignment(.center)
+            
+            Button("다시 시도") {
+                Task { await viewModel.fetchProblemDetail() }
+            }
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundColor(.white)
+            .padding(.horizontal, 24)
+            .padding(.vertical, 12)
+            .background(Color(.customBlue500))
+            .cornerRadius(8)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
     var learnButton: some View {
-        Button(action: {
-            // TODO: 학습하러가기 동작 구현
-        }) {
+        Button(action: { /* 학습 동작 */ }) {
             Text("학습하러 가기")
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundColor(.white)
@@ -73,7 +125,11 @@ private extension ProblemDetailView {
 #Preview {
     NavigationView {
         ProblemDetailView(
-            data: MockDailyResultData.incorrectSample
+            viewModel: ProblemDetailViewModel(
+                service: DailyServiceImpl(),
+                questionId: 1,
+                dayNumber: 1
+            )
         )
     }
 }

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemDetailView.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemDetailView.swift
@@ -6,10 +6,12 @@
 //
 
 import SwiftUI
+import Combine
 
 struct ProblemDetailView: View {
 
     @ObservedObject var viewModel: ProblemDetailViewModel
+    let learnButtonTapInput: PassthroughSubject<Void, Never>
 
     var body: some View {
             ZStack {
@@ -18,9 +20,6 @@ struct ProblemDetailView: View {
             }
             .navigationTitle("오답노트")
             .navigationBarTitleDisplayMode(.inline)
-            .onAppear {
-                Task { await viewModel.fetchProblemDetail() }
-            }
         }
     }
 
@@ -108,7 +107,7 @@ private extension ProblemDetailView {
     }
 
     var learnButton: some View {
-        Button(action: { /* 학습 동작 */ }) {
+        Button(action: { learnButtonTapInput.send(()) }) {
             Text("학습하러 가기")
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundColor(.white)
@@ -129,7 +128,8 @@ private extension ProblemDetailView {
                 service: DailyServiceImpl(),
                 questionId: 1,
                 dayNumber: 1
-            )
+            ),
+            learnButtonTapInput: PassthroughSubject<Void, Never>()
         )
     }
 }

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemDetailView.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemDetailView.swift
@@ -12,6 +12,7 @@ struct ProblemDetailView: View {
 
     @ObservedObject var viewModel: ProblemDetailViewModel
     let learnButtonTapInput: PassthroughSubject<Void, Never>
+    let conceptTapInput: PassthroughSubject<String, Never>
 
     var body: some View {
             ZStack {
@@ -63,7 +64,8 @@ private extension ProblemDetailView {
                     
                     ProblemKeyConceptsView(
                         keyConcepts: data.keyConcepts,
-                        subject: data.title
+                        subject: data.title,
+                        onConceptTap: conceptTapInput
                     )
                 }
 
@@ -129,7 +131,8 @@ private extension ProblemDetailView {
                 questionId: 1,
                 dayNumber: 1
             ),
-            learnButtonTapInput: PassthroughSubject<Void, Never>()
+            learnButtonTapInput: PassthroughSubject<Void, Never>(),
+            conceptTapInput: PassthroughSubject<String, Never>()
         )
     }
 }

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemDetailView.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemDetailView.swift
@@ -1,5 +1,5 @@
 //
-//  ProblemExplanationView.swift
+//  ProblemDetailView.swift
 //  QRIZ
 //
 //  Created by Claude on 12/30/25.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct ProblemExplanationView: View {
+struct ProblemDetailView: View {
 
     let data: DailyResultDetail
 
@@ -50,7 +50,7 @@ struct ProblemExplanationView: View {
 
 // MARK: - Subviews
 
-private extension ProblemExplanationView {
+private extension ProblemDetailView {
 
     /// 학습하러가기 버튼
     var learnButton: some View {
@@ -72,7 +72,7 @@ private extension ProblemExplanationView {
 
 #Preview {
     NavigationView {
-        ProblemExplanationView(
+        ProblemDetailView(
             data: MockDailyResultData.incorrectSample
         )
     }

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemExplanationView.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemExplanationView.swift
@@ -13,7 +13,7 @@ struct ProblemExplanationView: View {
 
     var body: some View {
         ScrollView {
-            VStack(spacing: 20) {
+            VStack(spacing: 32) {
                 ProblemHeaderCardView(data: data.headerData) // 헤더 카드
 
                 VStack(spacing: 8) {
@@ -23,6 +23,11 @@ struct ProblemExplanationView: View {
                         userAnswer: data.checked ?? 0
                     ) // 정답 정보
                 }
+
+                ProblemSolutionView(
+                    keyConcepts: data.keyConcepts,
+                    solutionText: data.solution
+                ) // 풀이 섹션
             }
             .padding(.horizontal, 18)
             .padding(.top, 16)

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemExplanationView.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemExplanationView.swift
@@ -28,6 +28,11 @@ struct ProblemExplanationView: View {
                     keyConcepts: data.keyConcepts,
                     solutionText: data.solution
                 ) // 풀이 섹션
+                
+                ProblemKeyConceptsView(
+                    keyConcepts: data.keyConcepts,
+                    subject: data.title
+                ) // 활용된 개념 섹션
             }
             .padding(.horizontal, 18)
             .padding(.top, 16)

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemExplanationView.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemExplanationView.swift
@@ -1,0 +1,37 @@
+//
+//  ProblemExplanationView.swift
+//  QRIZ
+//
+//  Created by Claude on 12/30/25.
+//
+
+import SwiftUI
+
+struct ProblemExplanationView: View {
+
+    let data: DailyResultDetail
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                ProblemHeaderCardView(data: data.headerData)        // 헤더 카드
+                ProblemQuestionSectionView(data: data.questionData) // 문제 섹션
+            }
+            .padding(.horizontal, 18)
+            .padding(.top, 16)
+        }
+        .background(Color.customBlue50)
+        .navigationTitle("오답노트")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    NavigationView {
+        ProblemExplanationView(
+            data: MockDailyResultData.incorrectSample
+        )
+    }
+}

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemExplanationView.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemExplanationView.swift
@@ -14,8 +14,15 @@ struct ProblemExplanationView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 20) {
-                ProblemHeaderCardView(data: data.headerData)        // 헤더 카드
-                ProblemQuestionSectionView(data: data.questionData) // 문제 섹션
+                ProblemHeaderCardView(data: data.headerData) // 헤더 카드
+
+                VStack(spacing: 8) {
+                    ProblemQuestionSectionView(data: data.questionData) // 문제 섹션
+                    ProblemResultView(
+                        correctAnswer: data.answer,
+                        userAnswer: data.checked ?? 0
+                    ) // 정답 정보
+                }
             }
             .padding(.horizontal, 18)
             .padding(.top, 16)

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemExplanationView.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemExplanationView.swift
@@ -19,6 +19,7 @@ struct ProblemExplanationView: View {
 
                 VStack(spacing: 8) {
                     ProblemQuestionSectionView(data: data.questionData) // 문제 섹션
+                    
                     ProblemResultView(
                         correctAnswer: data.answer,
                         userAnswer: data.checked ?? 0
@@ -34,13 +35,36 @@ struct ProblemExplanationView: View {
                     keyConcepts: data.keyConcepts,
                     subject: data.title
                 ) // 활용된 개념 섹션
+
+                learnButton // 학습하러가기 버튼
             }
             .padding(.horizontal, 18)
             .padding(.top, 16)
+            .padding(.bottom, 12)
         }
         .background(Color.customBlue50)
         .navigationTitle("오답노트")
         .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// MARK: - Subviews
+
+private extension ProblemExplanationView {
+
+    /// 학습하러가기 버튼
+    var learnButton: some View {
+        Button(action: {
+            // TODO: 학습하러가기 동작 구현
+        }) {
+            Text("학습하러 가기")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .frame(height: 48)
+                .background(Color(.customBlue500))
+                .cornerRadius(8)
+        }
     }
 }
 

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemExplanationView.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemExplanationView.swift
@@ -14,7 +14,8 @@ struct ProblemExplanationView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 32) {
-                ProblemHeaderCardView(data: data.headerData) // 헤더 카드
+                ProblemHeaderCardView(data: data.headerData)
+                    .padding(.bottom, 16)
 
                 VStack(spacing: 8) {
                     ProblemQuestionSectionView(data: data.questionData) // 문제 섹션

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemHeaderCardView.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemHeaderCardView.swift
@@ -1,0 +1,127 @@
+//
+//  ProblemHeaderCardView.swift
+//  QRIZ
+//
+//  Created by Claude on 12/30/25.
+//
+
+import SwiftUI
+
+struct ProblemHeaderCardView: View {
+
+    let data: ProblemHeaderData
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            headerSection // 결과 아이콘 및 시험 제목
+            infoSection  // 과목명 및 문제 번호
+            tagSection  // 태그 영역
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(24)
+        .background(Color.white)
+        .cornerRadius(8)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color(.coolNeutral100), lineWidth: 1)
+        )
+        .overlay(alignment: .bottom) {
+            TriangleBorder()
+                .fill(Color.white)
+                .overlay(
+                    TriangleBorder()
+                        .stroke(Color(.coolNeutral100), lineWidth: 1)
+                )
+                .frame(width: 20, height: 16)
+                .offset(y: 15)
+        }
+    }
+}
+
+// MARK: - Subviews
+private extension ProblemHeaderCardView {
+    
+    /// 정답 여부와 시험 제목
+    var headerSection: some View {
+        HStack(spacing: 14) {
+            Text(data.isCorrect ? "✓" : "✕")
+                .font(.system(size: 24))
+                .foregroundColor(data.isCorrect ? .customMint600 : .customRed500)
+
+            Text(data.examTitle)
+                .font(.system(size: 16, weight: .bold))
+                .foregroundColor(Color(.coolNeutral800))
+        }
+    }
+    
+    /// 과목명 | 문제 번호
+    var infoSection: some View {
+        HStack(spacing: 8) {
+            Text(data.subject)
+                .font(.system(size: 14, weight: .regular))
+                .foregroundColor(Color(.coolNeutral500))
+
+            Rectangle()
+                .fill(Color(.coolNeutral200))
+                .frame(width: 1, height: 13)
+
+            Text("\(data.questionNumber)번")
+                .font(.system(size: 14, weight: .regular))
+                .foregroundColor(Color(.coolNeutral500))
+        }
+    }
+    
+    /// 태그 목록
+    var tagSection: some View {
+        HStack(spacing: 8) {
+            ForEach(data.tags, id: \.self) { tag in
+                TagChip(text: tag)
+            }
+        }
+        .padding(.top, 4)
+    }
+}
+
+// MARK: - Tag Chip
+
+private struct TagChip: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundColor(Color(.customBlue400))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 8)
+            .background(Color(.customBlue100))
+            .cornerRadius(6)
+    }
+}
+
+// MARK: - Triangle
+
+private struct TriangleBorder: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.minX, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.midX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+        return path
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ProblemHeaderCardView(
+        data: ProblemHeaderData(
+            isCorrect: false,
+            examTitle: "2023년도 모의고사",
+            subject: "1과목",
+            questionNumber: 5,
+            tags: ["엔터티", "식별자"]
+        )
+    )
+    .padding()
+    .background(Color(.systemGroupedBackground))
+}

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemKeyConceptsView.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemKeyConceptsView.swift
@@ -6,11 +6,13 @@
 //
 
 import SwiftUI
+import Combine
 
 struct ProblemKeyConceptsView: View {
 
     let keyConcepts: String
     let subject: String
+    let onConceptTap: PassthroughSubject<String, Never>
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -36,7 +38,9 @@ private extension ProblemKeyConceptsView {
     var conceptsContent: some View {
         VStack(spacing: 8) {
             ForEach(conceptTags, id: \.self) { concept in
-                ConceptCard(concept: concept, subject: subject)
+                ConceptCard(concept: concept, subject: subject) {
+                    onConceptTap.send(concept)
+                }
             }
         }
     }
@@ -52,6 +56,7 @@ private extension ProblemKeyConceptsView {
 private struct ConceptCard: View {
     let concept: String
     let subject: String
+    let onTap: () -> Void
 
     var body: some View {
         HStack {
@@ -80,13 +85,20 @@ private struct ConceptCard: View {
             RoundedRectangle(cornerRadius: 12)
                 .stroke(Color(.coolNeutral200), lineWidth: 1)
         )
+        .onTapGesture {
+            onTap()
+        }
     }
 }
 
 // MARK: - Preview
 
 #Preview {
-    ProblemKeyConceptsView(keyConcepts: "엔터티, 식별자", subject: "1과목")
-        .padding()
-        .background(Color(.systemGroupedBackground))
+    ProblemKeyConceptsView(
+        keyConcepts: "엔터티, 식별자",
+        subject: "1과목",
+        onConceptTap: PassthroughSubject<String, Never>()
+    )
+    .padding()
+    .background(Color(.systemGroupedBackground))
 }

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemKeyConceptsView.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemKeyConceptsView.swift
@@ -1,0 +1,92 @@
+//
+//  ProblemKeyConceptsView.swift
+//  QRIZ
+//
+//  Created by Claude on 1/2/26.
+//
+
+import SwiftUI
+
+struct ProblemKeyConceptsView: View {
+
+    let keyConcepts: String
+    let subject: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            title // 타이틀
+            conceptsContent // 활용된 개념 내용
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Subviews
+
+private extension ProblemKeyConceptsView {
+
+    /// "활용된 개념" 타이틀
+    var title: some View {
+        Text("활용된 개념")
+            .font(.system(size: 20, weight: .bold))
+            .foregroundColor(Color(.coolNeutral800))
+    }
+
+    /// 활용된 개념 카드 목록
+    var conceptsContent: some View {
+        VStack(spacing: 8) {
+            ForEach(conceptTags, id: \.self) { concept in
+                ConceptCard(concept: concept, subject: subject)
+            }
+        }
+    }
+
+    /// keyConcepts를 쉼표로 분리하여 태그 배열로 변환
+    var conceptTags: [String] {
+        keyConcepts.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+    }
+}
+
+// MARK: - Concept Card
+
+private struct ConceptCard: View {
+    let concept: String
+    let subject: String
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(concept)
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundColor(Color(.coolNeutral700))
+
+                Text(subject)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(Color(.coolNeutral500))
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(Color(.coolNeutral800))
+        }
+        .padding(.vertical, 12)
+        .padding(.horizontal, 18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.white)
+        .cornerRadius(12)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color(.coolNeutral200), lineWidth: 1)
+        )
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ProblemKeyConceptsView(keyConcepts: "엔터티, 식별자", subject: "1과목")
+        .padding()
+        .background(Color(.systemGroupedBackground))
+}

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemOptionView.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemOptionView.swift
@@ -1,0 +1,107 @@
+//
+//  ProblemOptionView.swift
+//  QRIZ
+//
+//  Created by Claude on 12/30/25.
+//
+
+import SwiftUI
+
+struct ProblemOptionView: View {
+    
+    let option: OptionData
+    
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            indexCircle // 옵션 번호
+            optionText // 옵션 텍스트
+        }
+        .padding(16)
+        .background(optionBackgroundColor)
+    }
+}
+
+// MARK: - Subviews
+
+private extension ProblemOptionView {
+    
+    /// 옵션 번호 (1, 2, 3) 아이콘
+    var indexCircle: some View {
+        Text("\(option.number)")
+            .font(.system(size: 16, weight: .bold))
+            .foregroundColor(numberTextColor)
+            .frame(width: 40, height: 40)
+            .background(numberBackgroundColor)
+            .clipShape(Circle())
+            .overlay(
+                Circle()
+                    .stroke(Color(.coolNeutral700),
+                            lineWidth: option.state == .normal ? 1 : 0)
+            )
+    }
+    
+    /// 옵션 본문 텍스트
+    var optionText: some View {
+        Text(option.text)
+            .font(.system(size: 16))
+            .foregroundColor(Color(.coolNeutral800))
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Color
+private extension ProblemOptionView {
+    
+    var numberTextColor: Color {
+        option.state == .normal ? .black : .white
+    }
+
+    var numberBackgroundColor: Color {
+        switch option.state {
+        case .normal:    return .white
+        case .correct:   return Color(.customBlue500)
+        case .incorrect: return Color(.customRed500)
+        }
+    }
+
+    var optionBackgroundColor: Color {
+        switch option.state {
+        case .normal:    return .white
+        case .correct:   return Color(.customBlue500).opacity(0.14)
+        case .incorrect: return Color(.customRed500).opacity(0.14)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    VStack(spacing: 12) {
+        ProblemOptionView(
+            option: OptionData(
+                number: 1,
+                text: "SELECT * FROM table WHERE id = 1;",
+                state: .normal
+            )
+        )
+        
+        ProblemOptionView(
+            option: OptionData(
+                number: 2,
+                text: "SELECT * FROM table WHERE id = 2;",
+                state: .correct
+            )
+        )
+        
+        ProblemOptionView(
+            option: OptionData(
+                number: 3,
+                text: "SELECT * FROM table WHERE id = 3;",
+                state: .incorrect
+            )
+        )
+    }
+    .padding()
+    .background(Color(.systemGroupedBackground))
+}

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemQuestionSectionView.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemQuestionSectionView.swift
@@ -62,6 +62,7 @@ extension ProblemQuestionSectionView {
                 .lineSpacing(4)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.leading, 16)
     }
     
     /// 추가 설명 (SQL 코드)
@@ -69,9 +70,8 @@ extension ProblemQuestionSectionView {
         Text(description)
             .font(.system(.subheadline, design: .monospaced))
             .foregroundColor(Color(.coolNeutral800))
-            .padding(16)
+            .padding(.leading, 16)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .cornerRadius(8)
             .fixedSize(horizontal: false, vertical: true)
     }
     

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemQuestionSectionView.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemQuestionSectionView.swift
@@ -1,0 +1,98 @@
+//
+//  ProblemQuestionSectionView.swift
+//  QRIZ
+//
+//  Created by Claude on 12/30/25.
+//
+
+import SwiftUI
+
+struct ProblemQuestionSectionView: View {
+    
+    let data: ProblemQuestionData
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            title // 타이틀
+            
+            VStack(alignment: .leading, spacing: 16) {
+                questionHeader // 질문 텍스트
+                
+                if let description = data.description, !description.isEmpty {
+                    descriptionBox(description)
+                }
+                
+                optionsList // 사지선다
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 30)
+            .background(Color.white)
+            .cornerRadius(12)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Color(.coolNeutral200), lineWidth: 1.5)
+            )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Subviews
+
+extension ProblemQuestionSectionView {
+    
+    /// "문제" 타이틀
+    var title: some View {
+        Text("문제")
+            .font(.system(size: 20, weight: .bold))
+            .foregroundColor(Color(.coolNeutral800))
+    }
+    
+    /// 문제 번호와 질문 텍스트
+    var questionHeader: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("\(String(format: "%02d", data.questionNumber)).")
+                .font(.system(size: 16, weight: .bold))
+                .foregroundColor(Color(.coolNeutral800))
+            
+            Text(data.questionText)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundColor(Color(.coolNeutral800))
+                .fixedSize(horizontal: false, vertical: true)
+                .lineSpacing(4)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    
+    /// 추가 설명 (SQL 코드)
+    func descriptionBox(_ description: String) -> some View {
+        Text(description)
+            .font(.system(.subheadline, design: .monospaced))
+            .foregroundColor(Color(.coolNeutral800))
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .cornerRadius(8)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+    
+    /// 선택지 목록 (사지선다)
+    var optionsList: some View {
+        VStack(spacing: 4) {
+            ForEach(data.options, id: \.number) { option in
+                ProblemOptionView(option: option)
+            }
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ScrollView {
+        ProblemQuestionSectionView(
+            data: MockDailyResultData.incorrectSample.questionData
+        )
+        .padding()
+    }
+    .background(Color(.systemGroupedBackground))
+}

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemResultView.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemResultView.swift
@@ -1,0 +1,60 @@
+//
+//  ProblemResultView.swift
+//  QRIZ
+//
+//  Created by Claude on 12/31/25.
+//
+
+import SwiftUI
+
+struct ProblemResultView: View {
+    
+    let correctAnswer: Int
+    let userAnswer: Int
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            correctAnswerText
+            userAnswerText
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 18)
+        .padding(.vertical, 12)
+        .background(Color.white)
+        .cornerRadius(12)
+        .overlay(border)
+    }
+}
+
+// MARK: - Subviews
+
+private extension ProblemResultView {
+    
+    var correctAnswerText: some View {
+        Text("정답: \(correctAnswer)번")
+            .font(.system(size: 16, weight: .bold))
+            .foregroundColor(Color(.coolNeutral800))
+    }
+    
+    var userAnswerText: some View {
+        Text("내가 고른 답: \(userAnswer)번")
+            .font(.system(size: 14))
+            .foregroundColor(Color(.coolNeutral500))
+    }
+    
+    var border: some View {
+        RoundedRectangle(cornerRadius: 12)
+            .stroke(Color(.coolNeutral200), lineWidth: 1.5)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ProblemResultView(
+        correctAnswer: 2,
+        userAnswer: 3
+    )
+    .padding()
+    .background(Color(.systemGroupedBackground))
+}

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemSolutionView.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/View/ProblemSolutionView.swift
@@ -1,0 +1,82 @@
+//
+//  ProblemSolutionView.swift
+//  QRIZ
+//
+//  Created by Claude on 12/31/25.
+//
+
+import SwiftUI
+
+struct ProblemSolutionView: View {
+
+    let keyConcepts: String
+    let solutionText: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            title // 타이틀
+            solutionContent // 풀이 내용
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Subviews
+
+private extension ProblemSolutionView {
+
+    /// "풀이" 타이틀
+    var title: some View {
+        Text("풀이")
+            .font(.system(size: 20, weight: .bold))
+            .foregroundColor(Color(.coolNeutral800))
+    }
+
+    /// 풀이 내용 박스
+    var solutionContent: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            // 주제
+            Text(keyConcepts)
+                .font(.system(size: 16, weight: .bold))
+                .foregroundColor(Color(.coolNeutral800))
+
+            // 구분선
+            Divider()
+                .background(Color(.coolNeutral200))
+
+            // 풀이 내용
+            Text(solutionText)
+                .font(.system(size: 14, weight: .regular))
+                .foregroundColor(Color(.coolNeutral500))
+                .lineSpacing(8)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.white)
+        .cornerRadius(12)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color(.coolNeutral200), lineWidth: 1.5)
+        )
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ProblemSolutionView(
+        keyConcepts: "조인",
+        solutionText: """
+        최적의 해결방안 선택 이유:
+        1. FULL OUTER JOIN으로 모든 케이스 포함
+        2. NVL로 NULL 부서명 처리
+        3. COUNT(employee_id)로 정확한 직원 수 계산
+        4. CASE 식으로 NULL 정렬 처리
+        5. ORDER BY로 정렬 요건 충족
+        """
+    )
+    .padding()
+    .background(Color(.systemGroupedBackground))
+}

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/ViewController/ProblemDetailViewController.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/ViewController/ProblemDetailViewController.swift
@@ -42,8 +42,25 @@ final class ProblemDetailViewController: UIHostingController<ProblemDetailView> 
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureNavigationTitle()
         bind()
         input.send(.viewDidLoad)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        configureNavigationBar()
+    }
+
+    private func configureNavigationTitle() {
+        navigationItem.title = "오답노트"
+    }
+
+    private func configureNavigationBar() {
+        let appearance = UINavigationBar.defaultBackButtonStyle()
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.compactAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
     }
 
     private func bind() {

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/ViewController/ProblemDetailViewController.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/ViewController/ProblemDetailViewController.swift
@@ -12,9 +12,11 @@ import SwiftUI
 final class ProblemDetailViewController: UIHostingController<ProblemDetailView> {
 
     weak var coordinator: MistakeNoteCoordinator?
+    private let viewModel: ProblemDetailViewModel
 
-    init(data: DailyResultDetail) {
-        let swiftUIView = ProblemDetailView(data: data)
+    init(viewModel: ProblemDetailViewModel) {
+        self.viewModel = viewModel
+        let swiftUIView = ProblemDetailView(viewModel: viewModel)
         super.init(rootView: swiftUIView)
         self.hidesBottomBarWhenPushed = true
     }

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/ViewController/ProblemDetailViewController.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/ViewController/ProblemDetailViewController.swift
@@ -7,16 +7,25 @@
 
 import UIKit
 import SwiftUI
+import Combine
 
 @MainActor
 final class ProblemDetailViewController: UIHostingController<ProblemDetailView> {
 
     weak var coordinator: MistakeNoteCoordinator?
     private let viewModel: ProblemDetailViewModel
+    private let input: PassthroughSubject<ProblemDetailViewModel.Input, Never> = .init()
+    private let learnButtonTapInput: PassthroughSubject<Void, Never> = .init()
+    private var cancellables = Set<AnyCancellable>()
+    private let onNavigateToConcept: () -> Void
 
-    init(viewModel: ProblemDetailViewModel) {
+    init(viewModel: ProblemDetailViewModel, onNavigateToConcept: @escaping () -> Void) {
         self.viewModel = viewModel
-        let swiftUIView = ProblemDetailView(viewModel: viewModel)
+        self.onNavigateToConcept = onNavigateToConcept
+        let swiftUIView = ProblemDetailView(
+            viewModel: viewModel,
+            learnButtonTapInput: learnButtonTapInput
+        )
         super.init(rootView: swiftUIView)
         self.hidesBottomBarWhenPushed = true
     }
@@ -27,5 +36,24 @@ final class ProblemDetailViewController: UIHostingController<ProblemDetailView> 
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        bind()
+        input.send(.viewDidLoad)
+    }
+
+    private func bind() {
+        let learnButtonTapped = learnButtonTapInput.map { ProblemDetailViewModel.Input.learnButtonTapped }
+        let mergedInput = input.merge(with: learnButtonTapped)
+        let output = viewModel.transform(input: mergedInput.eraseToAnyPublisher())
+
+        output
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] event in
+                guard let self = self else { return }
+                switch event {
+                case .navigateToConcept:
+                    self.onNavigateToConcept()
+                }
+            }
+            .store(in: &cancellables)
     }
 }

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/ViewController/ProblemDetailViewController.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/ViewController/ProblemDetailViewController.swift
@@ -1,0 +1,29 @@
+//
+//  ProblemDetailViewController.swift
+//  QRIZ
+//
+//  Created by Claude on 12/30/25.
+//
+
+import UIKit
+import SwiftUI
+
+@MainActor
+final class ProblemDetailViewController: UIHostingController<ProblemDetailView> {
+
+    weak var coordinator: MistakeNoteCoordinator?
+
+    init(data: DailyResultDetail) {
+        let swiftUIView = ProblemDetailView(data: data)
+        super.init(rootView: swiftUIView)
+        self.hidesBottomBarWhenPushed = true
+    }
+
+    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/ViewModel/ProblemDetailViewModel.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/ViewModel/ProblemDetailViewModel.swift
@@ -1,0 +1,54 @@
+//
+//  ProblemDetailViewModel.swift
+//  QRIZ
+//
+//  Created by Claude on 1/3/26.
+//
+
+import Foundation
+import Combine
+
+@MainActor
+final class ProblemDetailViewModel: ObservableObject {
+
+    // MARK: - Published Properties
+    @Published var problemDetail: DailyResultDetail?
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    // MARK: - Private Properties
+    private let service: DailyService
+    private let questionId: Int
+    private let dayNumber: Int
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Initializers
+    init(service: DailyService, questionId: Int, dayNumber: Int) {
+        self.service = service
+        self.questionId = questionId
+        self.dayNumber = dayNumber
+
+        Task {
+            await fetchProblemDetail()
+        }
+    }
+
+    // MARK: - Methods
+    func fetchProblemDetail() async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            let response = try await service.getDailyResultDetail(
+                dayNumber: dayNumber,
+                questionId: questionId
+            )
+            problemDetail = response.data
+        } catch {
+            errorMessage = "문제 정보를 불러오는데 실패했습니다."
+            print("Failed to load problem detail: \(error)")
+        }
+
+        isLoading = false
+    }
+}

--- a/QRIZ/Feature/MistakeNote/ProblemExplanation/ViewModel/ProblemDetailViewModel.swift
+++ b/QRIZ/Feature/MistakeNote/ProblemExplanation/ViewModel/ProblemDetailViewModel.swift
@@ -15,10 +15,12 @@ final class ProblemDetailViewModel: ObservableObject {
     enum Input {
         case viewDidLoad
         case learnButtonTapped
+        case conceptTapped(concept: String)
     }
 
     enum Output {
-        case navigateToConcept
+        case navigateToConceptTab
+        case navigateToConceptDetail(chapter: Chapter, conceptItem: ConceptItem)
     }
 
     // MARK: - Published Properties
@@ -48,12 +50,44 @@ final class ProblemDetailViewModel: ObservableObject {
             case .viewDidLoad:
                 Task { await self.fetchProblemDetail() }
             case .learnButtonTapped:
-                output.send(.navigateToConcept)
+                output.send(.navigateToConceptTab)
+            case .conceptTapped(let concept):
+                if let (chapter, conceptItem) = self.findConceptItem(for: concept) {
+                    output.send(.navigateToConceptDetail(chapter: chapter, conceptItem: conceptItem))
+                }
             }
         }
         .store(in: &cancellables)
-        
+
         return output.eraseToAnyPublisher()
+    }
+
+    /// 개념 이름으로 Chapter와 ConceptItem을 찾는 메서드
+    private func findConceptItem(for conceptName: String) -> (Chapter, ConceptItem)? {
+        let normalizedInput = conceptName.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        for chapter in Chapter.allCases {
+            for conceptItem in chapter.conceptItems {
+                // 정확히 일치하는 경우
+                if conceptItem.title == normalizedInput {
+                    return (chapter, conceptItem)
+                }
+
+                // 대소문자 무시하고 비교
+                if conceptItem.title.lowercased() == normalizedInput.lowercased() {
+                    return (chapter, conceptItem)
+                }
+
+                // 공백 제거하고 비교 (예: "SELECT문" vs "SELECT 문")
+                let normalizedTitle = conceptItem.title.replacingOccurrences(of: " ", with: "")
+                let normalizedSearch = normalizedInput.replacingOccurrences(of: " ", with: "")
+                if normalizedTitle.lowercased() == normalizedSearch.lowercased() {
+                    return (chapter, conceptItem)
+                }
+            }
+        }
+
+        return nil
     }
 
     func fetchProblemDetail() async {

--- a/QRIZ/Feature/TabBar/TabBarCoordinator.swift
+++ b/QRIZ/Feature/TabBar/TabBarCoordinator.swift
@@ -195,7 +195,15 @@ final class TabBarCoordinatorImpl: TabBarCoordinator {
 extension TabBarCoordinatorImpl: HomeCoordinatorDelegate {
     func moveToConcept() {
         if let tabBarController = self.tabBarController {
-            tabBarController.selectedIndex = 1
+            UIView.transition(
+                with: tabBarController.view,
+                duration: 0.3,
+                options: .transitionCrossDissolve,
+                animations: {
+                    tabBarController.selectedIndex = 1
+                },
+                completion: nil
+            )
         }
     }
 }

--- a/QRIZ/Feature/TestComponents/View/ResultGradeListCellView.swift
+++ b/QRIZ/Feature/TestComponents/View/ResultGradeListCellView.swift
@@ -64,6 +64,7 @@ struct ResultGradeListCellView: View {
     ResultGradeListCellView(
         gradeResult: GradeResult(
             id: 1,
+            questionId: 168,
             skillName: "엔터티",
             question: """
                 아래 테이블 T<S<R이 각각 다음과 같이 선언되었다.

--- a/QRIZ/Feature/TestComponents/View/ResultGradeListCellView.swift
+++ b/QRIZ/Feature/TestComponents/View/ResultGradeListCellView.swift
@@ -8,8 +8,9 @@
 import SwiftUI
 
 struct ResultGradeListCellView: View {
-
+    
     let gradeResult: GradeResult
+    let onTap: () -> Void
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -22,9 +23,9 @@ struct ResultGradeListCellView: View {
             }
             
             Text("\(gradeResult.question)")
-            .font(.system(size: 14, weight: .regular))
-            .foregroundStyle(.coolNeutral600)
-            .lineLimit(2)
+                .font(.system(size: 14, weight: .regular))
+                .foregroundStyle(.coolNeutral600)
+                .lineLimit(2)
             
             HStack {
                 Text("\(gradeResult.skillName)")
@@ -38,6 +39,9 @@ struct ResultGradeListCellView: View {
         .padding(EdgeInsets(top: 20, leading: 16, bottom: 20, trailing: 16))
         .background(.white)
         .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.customBlue100, lineWidth: 1))
+        .onTapGesture {
+            onTap()
+        }
     }
     
     @ViewBuilder
@@ -57,12 +61,15 @@ struct ResultGradeListCellView: View {
 }
 
 #Preview {
-    ResultGradeListCellView(gradeResult: GradeResult(
-                            id: 1,
-                            skillName: "엔터티",
-                            question: """
-                                아래 테이블 T<S<R이 각각 다음과 같이 선언되었다. 
-                                다음 중 DELETE FROM T;를 수행한 후에 테이블 R에 남아있는 데이터로 가장 적절한 것은?
-                            """,
-                            correction: false))
+    ResultGradeListCellView(
+        gradeResult: GradeResult(
+            id: 1,
+            skillName: "엔터티",
+            question: """
+                아래 테이블 T<S<R이 각각 다음과 같이 선언되었다.
+                다음 중 DELETE FROM T;를 수행한 후에 테이블 R에 남아있는 데이터로 가장 적절한 것은?
+            """,
+            correction: false),
+        onTap: {}
+    )
 }

--- a/QRIZ/Feature/TestComponents/View/TestResultGradesListView.swift
+++ b/QRIZ/Feature/TestComponents/View/TestResultGradesListView.swift
@@ -6,10 +6,12 @@
 //
 
 import SwiftUI
+import Combine
 
 struct TestResultGradesListView: View {
     
     @ObservedObject var resultGradeListData: ResultGradeListData
+    let onProblemTap: PassthroughSubject<Int, Never>
     
     var body: some View {
         LazyVStack(spacing: 16) {
@@ -21,7 +23,9 @@ struct TestResultGradesListView: View {
             }
             
             ForEach(resultGradeListData.gradeResultList) { gradeResult in
-                ResultGradeListCellView(gradeResult: gradeResult)
+                ResultGradeListCellView(gradeResult: gradeResult) {
+                    onProblemTap.send(gradeResult.id)
+                }
             }
         }
         .padding(EdgeInsets(top: 24, leading: 18, bottom: 16, trailing: 18))
@@ -30,5 +34,8 @@ struct TestResultGradesListView: View {
 }
 
 #Preview {
-    TestResultGradesListView(resultGradeListData: ResultGradeListData())
+    TestResultGradesListView(
+        resultGradeListData: ResultGradeListData(),
+        onProblemTap: PassthroughSubject<Int, Never>()
+    )
 }

--- a/QRIZ/Feature/TestComponents/View/TestResultGradesListView.swift
+++ b/QRIZ/Feature/TestComponents/View/TestResultGradesListView.swift
@@ -24,7 +24,7 @@ struct TestResultGradesListView: View {
             
             ForEach(resultGradeListData.gradeResultList) { gradeResult in
                 ResultGradeListCellView(gradeResult: gradeResult) {
-                    onProblemTap.send(gradeResult.id)
+                    onProblemTap.send(gradeResult.questionId)
                 }
             }
         }

--- a/QRIZ/Utils/Model/ProblemDetail/MockDailyResultData.swift
+++ b/QRIZ/Utils/Model/ProblemDetail/MockDailyResultData.swift
@@ -1,0 +1,77 @@
+//
+//  MockDailyResultData.swift
+//  QRIZ
+//
+//  Created by Claude on 12/30/25.
+//
+
+import Foundation
+
+enum MockDailyResultData {
+
+    /// 정답 샘플
+    static let correctSample = DailyResultDetail(
+        skillName: "조인",
+        questionText: "다음 요구사항을 만족하는 가장 적절한 SQL문은?",
+        questionNum: 2,
+        description: """
+        ```sql
+        [요구사항]
+        1. 부서별 사원 수 조회
+        2. 사원이 없는 부서도 포함
+        3. 부서가 없는 사원도 포함
+        4. 부서 이름 기준 오름차순 정렬
+        ```
+        """,
+        option1: "SELECT COALESCE(d.department_name, 'No Department') as dept_name, COUNT(e.employee_id) as emp_count FROM departments d FULL OUTER JOIN employees e ON d.department_id = e.department_id GROUP BY d.department_name ORDER BY dept_name;",
+        option2: "SELECT d.department_name, COUNT(e.employee_id) as emp_count FROM departments d LEFT OUTER JOIN employees e ON d.department_id = e.department_id GROUP BY d.department_name ORDER BY d.department_name NULLS LAST;",
+        option3: "SELECT NVL(d.department_name, 'No Department') as dept_name, COUNT(e.employee_id) as emp_count FROM departments d FULL OUTER JOIN employees e ON d.department_id = e.department_id GROUP BY d.department_name ORDER BY CASE WHEN d.department_name IS NULL THEN 'No Department' ELSE d.department_name END;",
+        option4: "SELECT COALESCE(d.department_name, 'No Department') as dept_name, COUNT(*) as emp_count FROM employees e RIGHT OUTER JOIN departments d ON e.department_id = d.department_id GROUP BY d.department_name ORDER BY dept_name;",
+        answer: 3,
+        solution: """
+        최적의 해결방안 선택 이유:
+        1. FULL OUTER JOIN으로 모든 케이스 포함
+        2. NVL로 NULL 부서명 처리
+        3. COUNT(employee_id)로 정확한 직원 수 계산
+        4. CASE 식으로 NULL 정렬 처리
+        5. ORDER BY로 정렬 요건 충족
+        """,
+        checked: 3,
+        correction: true,
+        testInfo: "Day1",
+        skillId: 17,
+        title: "2과목",
+        keyConcepts: "조인"
+    )
+
+    /// 오답 샘플
+    static let incorrectSample = DailyResultDetail(
+        skillName: "조인",
+        questionText: "다음 요구사항을 만족하는 가장 적절한 SQL문은?",
+        questionNum: 1,
+        description: """
+        ```sql
+        [요구사항]
+        1. 직원의 이름과 부서명 조회
+        2. 부서가 없는 직원도 포함
+        ```
+        """,
+        option1: "SELECT e.name, d.department_name FROM employees e INNER JOIN departments d ON e.department_id = d.department_id;",
+        option2: "SELECT e.name, d.department_name FROM employees e LEFT OUTER JOIN departments d ON e.department_id = d.department_id;",
+        option3: "SELECT e.name, d.department_name FROM employees e RIGHT OUTER JOIN departments d ON e.department_id = d.department_id;",
+        option4: "SELECT e.name, d.department_name FROM employees e FULL OUTER JOIN departments d ON e.department_id = d.department_id;",
+        answer: 2,
+        solution: """
+        최적의 해결방안 선택 이유:
+        1. LEFT OUTER JOIN으로 부서가 없는 직원도 포함
+        2. INNER JOIN은 부서가 있는 직원만 조회
+        3. RIGHT OUTER JOIN은 직원이 없는 부서도 포함되어 요건 불충족
+        """,
+        checked: 1,
+        correction: false,
+        testInfo: "Day1",
+        skillId: 17,
+        title: "2과목",
+        keyConcepts: "조인"
+    )
+}

--- a/QRIZ/Utils/Model/ProblemDetail/ProblemHeaderData.swift
+++ b/QRIZ/Utils/Model/ProblemDetail/ProblemHeaderData.swift
@@ -1,0 +1,16 @@
+//
+//  ProblemHeaderData.swift
+//  QRIZ
+//
+//  Created by Claude on 12/30/25.
+//
+
+import Foundation
+
+struct ProblemHeaderData {
+    let isCorrect: Bool             // 정답 여부
+    let examTitle: String           // "2023년도 모의고사"
+    let subject: String             // "1과목"
+    let questionNumber: Int         // 5
+    let tags: [String]              // ["엔터티", "식별자"]
+}

--- a/QRIZ/Utils/Model/ProblemDetail/ProblemQuestionData.swift
+++ b/QRIZ/Utils/Model/ProblemDetail/ProblemQuestionData.swift
@@ -1,0 +1,79 @@
+//
+//  ProblemQuestionData.swift
+//  QRIZ
+//
+//  Created by Claude on 12/30/25.
+//
+
+import Foundation
+
+/// 문제 섹션 데이터
+struct ProblemQuestionData {
+    let questionNumber: Int         // 2
+    let questionText: String        // "다음 요구사항을 만족하는 가장 적절한 SQL문은?"
+    let description: String?        // 추가 설명 (마크다운)
+    let options: [OptionData]       // 4개 옵션
+}
+
+/// 옵션 데이터
+struct OptionData {
+    let number: Int                 // 1-4
+    let text: String                // 옵션 텍스트
+    let state: OptionState          // 상태 (정답/오답/일반)
+}
+
+/// 옵션 상태
+enum OptionState {
+    case normal                     // 일반 (회색)
+    case correct                    // 정답 (파란색)
+    case incorrect                  // 오답 (빨간색)
+}
+
+// MARK: - Helper Extensions
+
+extension DailyResultDetail {
+
+    /// 헤더 카드 데이터로 변환
+    var headerData: ProblemHeaderData {
+        ProblemHeaderData(
+            isCorrect: correction,
+            examTitle: testInfo,
+            subject: title,
+            questionNumber: questionNum,
+            tags: keyConcepts.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+        )
+    }
+
+    /// 문제 섹션 데이터로 변환
+    var questionData: ProblemQuestionData {
+        let optionTexts = [option1, option2, option3, option4]
+        let optionStates = optionTexts.enumerated().map { index, _ -> OptionState in
+            let optionNumber = index + 1
+            let isCorrect = (optionNumber == answer)
+            let isUserChoice = (optionNumber == checked)
+
+            if isCorrect {
+                return .correct
+            } else if isUserChoice {
+                return .incorrect
+            } else {
+                return .normal
+            }
+        }
+
+        let options = optionTexts.enumerated().map { index, text in
+            OptionData(
+                number: index + 1,
+                text: text,
+                state: optionStates[index]
+            )
+        }
+
+        return ProblemQuestionData(
+            questionNumber: questionNum,
+            questionText: questionText,
+            description: description.isEmpty ? nil : description,
+            options: options
+        )
+    }
+}

--- a/QRIZ/Utils/Model/ProblemDetail/ProblemQuestionData.swift
+++ b/QRIZ/Utils/Model/ProblemDetail/ProblemQuestionData.swift
@@ -72,7 +72,7 @@ extension DailyResultDetail {
         return ProblemQuestionData(
             questionNumber: questionNum,
             questionText: questionText,
-            description: description.isEmpty ? nil : description,
+            description: description,
             options: options
         )
     }

--- a/QRIZ/Utils/Model/TestModel/ResultGradeListData.swift
+++ b/QRIZ/Utils/Model/TestModel/ResultGradeListData.swift
@@ -12,7 +12,8 @@ final class ResultGradeListData: ObservableObject {
 }
 
 struct GradeResult: Identifiable {
-    var id: Int
+    var id: Int  // UI 표시용 순번
+    var questionId: Int  // 실제 API questionId
     var skillName: String
     var question: String
     var correction: Bool


### PR DESCRIPTION
 ## 🛠️ Task
  - 문제 상세보기 화면 UI 구현
  - DailyResultDetail API 연동 및 에러 처리
  - 활용된 개념 카드 클릭 시 해당 개념서 PDF로 이동
  - 학습하러 가기 버튼으로 개념서 탭 전환 (크로스 디졸브 애니메이션 적용)
  - questionId 정확한 전달을 위한 GradeResult 모델 수정

  ## 🌱 PR Point
  - **Coordinator 프로토콜 패턴**: `ProblemDetailCoordinating` 프로토콜로 네비게이션 로직 분리
  - **Input/Output 패턴**: ViewModel에서 사용자 액션(Input)과 네비게이션 이벤트(Output)를 명확히 분리
  - **UIHostingController 활용**: SwiftUI 뷰를 UIKit Navigation에 통합하여 기존 Coordinator 패턴 유지
  - **개념 매칭 로직**: 공백/대소문자를 무시한 유연한 개념 이름 검색으로 API 응답 다양성 대응
  - **questionId 추적**: 배열 인덱스가 아닌 실제 API questionId 사용으로 정확한 문제 식별
  - **NavigationBar 책임 분리**: Coordinator가 아닌 ViewController에서 appearance 관리

  ## 📸 스크린샷

  |    구현 내용    |   스크린샷   |
  | :-------------: | :----------: |
  | 문제 상세보기 화면 |  <img width="226" alt="simulator_screenshot_43EE870C-D82D-422E-8528-189E179B2261" src="https://github.com/user-attachments/assets/9d11d999-3a7e-4207-9e39-c312be77b42d" /> |

  ## 📮 Issue 번호
  - resolved: #95 