### PR TITLE
FEAT: 모의고사 결과 뷰 상세 보기 기능 구현(1.1.1)

### DIFF
--- a/Network/DTOs/Exam/ExamResultDetailRequest.swift
+++ b/Network/DTOs/Exam/ExamResultDetailRequest.swift
@@ -1,0 +1,41 @@
+//
+//  ExamResultDetailRequest.swift
+//  QRIZ
+//
+//  Created by Claude on 2/10/26.
+//
+
+import Foundation
+
+/// 모의고사 문제 상세 조회
+/// GET /api/v1/exam/result/{examId}/{questionId}
+struct ExamResultDetailRequest: Request {
+    typealias Response = ExamResultDetailResponse
+
+    let method: HTTPMethod = .get
+    private let accessToken: String
+    private let examId: Int
+    private let questionId: Int
+
+    var path: String {
+        "/api/v1/exam/result/\(examId)/\(questionId)"
+    }
+
+    var headers: HTTPHeader {
+        [
+            HTTPHeaderField.authorization.rawValue: accessToken
+        ]
+    }
+
+    init(accessToken: String, examId: Int, questionId: Int) {
+        self.accessToken = accessToken
+        self.examId = examId
+        self.questionId = questionId
+    }
+}
+
+struct ExamResultDetailResponse: Decodable {
+    let code: Int
+    let msg: String
+    let data: DailyResultDetail
+}

--- a/Network/Service/Exam/ExamService.swift
+++ b/Network/Service/Exam/ExamService.swift
@@ -17,6 +17,8 @@ protocol ExamService {
     func getExamScore(examId: Int) async throws -> ExamScoreResponse
     
     func getExamResult(examId: Int) async throws -> ExamResultResponse
+
+    func getExamResultDetail(examId: Int, questionId: Int) async throws -> ExamResultDetailResponse
 }
 
 final class ExamServiceImpl: ExamService {
@@ -56,7 +58,12 @@ final class ExamServiceImpl: ExamService {
         let request = ExamResultRequest(accessToken: getAccessToken(), examId: examId)
         return try await network.send(request)
     }
-    
+
+    func getExamResultDetail(examId: Int, questionId: Int) async throws -> ExamResultDetailResponse {
+        let request = ExamResultDetailRequest(accessToken: getAccessToken(), examId: examId, questionId: questionId)
+        return try await network.send(request)
+    }
+
     private func getAccessToken() -> String {
         let accessToken = keychainManager.retrieveToken(forKey: HTTPHeaderField.accessToken.rawValue) ?? ""
         return accessToken

--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -288,6 +288,7 @@
 		E2A6C14C2DC5E33F0059F960 /* TestSubmitRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A6C14B2DC5E33F0059F960 /* TestSubmitRequest.swift */; };
 		E2A6C3242DC610420059F960 /* ExamScoreRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A6C3232DC610420059F960 /* ExamScoreRequest.swift */; };
 		E2A6C6762DCA45970059F960 /* ExamResultRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A6C6752DCA45970059F960 /* ExamResultRequest.swift */; };
+		E2A6C6792DCA46A10059F960 /* ExamResultDetailRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A6C6782DCA46A10059F960 /* ExamResultDetailRequest.swift */; };
 		E2A6C7352DCA4C850059F960 /* ExamService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A6C7342DCA4C850059F960 /* ExamService.swift */; };
 		E2C084BE2D89AF2C0096CE20 /* PreviewResultInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C084BD2D89AF2C0096CE20 /* PreviewResultInfoView.swift */; };
 		E2C1016B2DF2E10200C3512E /* OnboardingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C1016A2DF2E10200C3512E /* OnboardingCoordinator.swift */; };
@@ -610,6 +611,7 @@
 		E2A6C14B2DC5E33F0059F960 /* TestSubmitRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSubmitRequest.swift; sourceTree = "<group>"; };
 		E2A6C3232DC610420059F960 /* ExamScoreRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamScoreRequest.swift; sourceTree = "<group>"; };
 		E2A6C6752DCA45970059F960 /* ExamResultRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamResultRequest.swift; sourceTree = "<group>"; };
+		E2A6C6782DCA46A10059F960 /* ExamResultDetailRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamResultDetailRequest.swift; sourceTree = "<group>"; };
 		E2A6C7342DCA4C850059F960 /* ExamService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExamService.swift; sourceTree = "<group>"; };
 		E2C084BD2D89AF2C0096CE20 /* PreviewResultInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewResultInfoView.swift; sourceTree = "<group>"; };
 		E2C1016A2DF2E10200C3512E /* OnboardingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCoordinator.swift; sourceTree = "<group>"; };
@@ -2104,6 +2106,7 @@
 				E2A6C14B2DC5E33F0059F960 /* TestSubmitRequest.swift */,
 				E2A6C3232DC610420059F960 /* ExamScoreRequest.swift */,
 				E2A6C6752DCA45970059F960 /* ExamResultRequest.swift */,
+				E2A6C6782DCA46A10059F960 /* ExamResultDetailRequest.swift */,
 			);
 			path = Exam;
 			sourceTree = "<group>";
@@ -2370,6 +2373,7 @@
 				B1296F402F34654B00252AD9 /* MistakeNoteEmptyView.swift in Sources */,
 				B15109832E04DFA400657506 /* ChangePasswordMainView.swift in Sources */,
 				E2A6C6762DCA45970059F960 /* ExamResultRequest.swift in Sources */,
+				E2A6C6792DCA46A10059F960 /* ExamResultDetailRequest.swift in Sources */,
 				E29CCD522D299AD5004AA30A /* PreviewResultIncorrectConceptsRankView.swift in Sources */,
 				E29CCD492D29867F004AA30A /* GreetingViewController.swift in Sources */,
 				B18CDF752DD425D100DD361A /* TermsAgreementAllView.swift in Sources */,

--- a/QRIZ/Feature/Exam/ExamResult/ViewController/ExamResultViewController.swift
+++ b/QRIZ/Feature/Exam/ExamResult/ViewController/ExamResultViewController.swift
@@ -46,8 +46,11 @@ final class ExamResultViewController: UIViewController {
         let conceptTapped = examResultHostingController.rootView.conceptTappedPublisher.map {
             ExamResultViewModel.Input.moveToConceptButtonClicked
         }
-        
-        let mergedInput = input.merge(with: resultDetailTapped, conceptTapped)
+        let problemTapped = examResultHostingController.rootView.problemTappedPublisher.map {
+            ExamResultViewModel.Input.problemTapped(questionId: $0)
+        }
+
+        let mergedInput = input.merge(with: resultDetailTapped, conceptTapped, problemTapped)
         let output = viewModel.transform(input: mergedInput.eraseToAnyPublisher())
         output
             .receive(on: DispatchQueue.main)
@@ -69,6 +72,8 @@ final class ExamResultViewController: UIViewController {
                     coordinator?.quitExam()
                 case .moveToResultDetail:
                     coordinator?.showResultDetail(resultDetailData: self.viewModel.resultDetailData)
+                case .showProblemDetail(let questionId):
+                    coordinator?.showProblemExplanation(questionId: questionId)
                 }
             }
             .store(in: &subscriptions)

--- a/QRIZ/Feature/Exam/ExamResult/ViewModel/ExamResultViewModel.swift
+++ b/QRIZ/Feature/Exam/ExamResult/ViewModel/ExamResultViewModel.swift
@@ -16,6 +16,7 @@ final class ExamResultViewModel {
         case cancelButtonClicked
         case moveToConceptButtonClicked
         case resultDetailButtonClicked
+        case problemTapped(questionId: Int)
     }
     
     enum Output {
@@ -23,6 +24,7 @@ final class ExamResultViewModel {
         case moveToExamList
         case moveToConcept
         case moveToResultDetail
+        case showProblemDetail(questionId: Int)
     }
     
     // MARK: - Properties
@@ -67,6 +69,8 @@ final class ExamResultViewModel {
                 output.send(.moveToConcept)
             case .resultDetailButtonClicked:
                 output.send(.moveToResultDetail)
+            case .problemTapped(let questionId):
+                output.send(.showProblemDetail(questionId: questionId))
             }
         }
         .store(in: &subscriptions)


### PR DESCRIPTION
## 🛠️ Task
- 모의고사 결과 화면에서 문제 탭 시 ProblemDetailViewController로 이동하여 문제 상세 정보를 확인할 수 있도록 구현
- 기존 데일리 결과 화면의 문제 상세 보기 패턴(DailyCoordinator)을 모의고사에도 동일하게 적용
- 모의고사 문제 상세 조회 API 연동

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 상세 보기 뷰 | <img width="226" alt="simulator_screenshot_BF048128-E4C4-479F-BBC9-24294BEE48CE" src="https://github.com/user-attachments/assets/19ab71f5-d907-4d07-8dc8-16185633f4b9" /> |

## 📮 Issue 번호
- resolved: #99 
