### PR TITLE
FIX: 모듈화 후속 버그 수정 및 UI 개선

### DIFF
--- a/Modules/Core/Auth/Sources/Auth/SocialLoginService.swift
+++ b/Modules/Core/Auth/Sources/Auth/SocialLoginService.swift
@@ -41,7 +41,7 @@ public final class SocialLoginServiceImpl: NSObject, SocialLoginService {
     }
 
     public func logoutKakao() async throws {
-        try await kakaoVoidCallback { UserApi.shared.logout(completion: $0) }
+        try? await kakaoVoidCallback { UserApi.shared.logout(completion: $0) }
         try await serverLogout()
     }
 

--- a/Modules/Core/Auth/Sources/Auth/SocialLoginService.swift
+++ b/Modules/Core/Auth/Sources/Auth/SocialLoginService.swift
@@ -3,7 +3,6 @@
 //  Auth
 //
 
-import UIKit
 import KakaoSDKCommon
 import KakaoSDKAuth
 import KakaoSDKUser

--- a/Modules/Core/ExamKit/Sources/ExamKit/QuestionUI/QuestionOptionLabel.swift
+++ b/Modules/Core/ExamKit/Sources/ExamKit/QuestionUI/QuestionOptionLabel.swift
@@ -54,7 +54,7 @@ public final class QuestionOptionLabel: UIView {
     }
 
     public func setOptionString(_ str: String) {
-        optionStringLabel.attributedText = NSAttributedString(text: str, lineSpacing: 8)
+        optionStringLabel.attributedText = NSAttributedString(text: str, lineSpacing: 6)
     }
 
     public func setOptionState(isSelected: Bool) {
@@ -88,7 +88,7 @@ extension QuestionOptionLabel {
             optionNumberLabel.widthAnchor.constraint(equalToConstant: 32),
             optionNumberLabel.heightAnchor.constraint(equalTo: optionNumberLabel.widthAnchor),
 
-            optionStringLabel.topAnchor.constraint(equalTo: topAnchor, constant: 24),
+            optionStringLabel.topAnchor.constraint(equalTo: optionNumberLabel.topAnchor),
             optionStringLabel.leadingAnchor.constraint(equalTo: optionNumberLabel.trailingAnchor, constant: 16),
             optionStringLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24),
             optionStringLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -24),

--- a/Modules/Core/ExamKit/Sources/ExamKit/QuestionUI/QuestionOptionLabel.swift
+++ b/Modules/Core/ExamKit/Sources/ExamKit/QuestionUI/QuestionOptionLabel.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 import DesignSystem
+import QRIZUtils
 
 public final class QuestionOptionLabel: UIView {
 
@@ -12,32 +13,33 @@ public final class QuestionOptionLabel: UIView {
 
     private let optionNumberLabel: UILabel = {
         let label = UILabel()
+        label.font = .systemFont(ofSize: 14, weight: .bold)
         label.textAlignment = .center
-        label.font = .boldSystemFont(ofSize: 16)
-        label.numberOfLines = 1
         label.layer.masksToBounds = true
-        label.layer.cornerRadius = 20
-        label.layer.borderColor = UIColor.coolNeutral700.cgColor
+        label.layer.cornerRadius = 4
         return label
     }()
 
     private let optionStringLabel: UILabel = {
         let label = UILabel()
-        label.textAlignment = .left
-        label.textColor = .coolNeutral700
         label.font = .systemFont(ofSize: 16, weight: .regular)
+        label.textColor = .coolNeutral800
         label.numberOfLines = 0
         return label
     }()
+
+    var onTap: (() -> Void)?
 
     // MARK: - Initialization
 
     public init(number: Int) {
         super.init(frame: .zero)
         optionNumberLabel.text = "\(number)"
-        setOptionState(isSelected: false)
+        setupUI()
         addSubviews()
         setupConstraints()
+        setOptionState(isSelected: false)
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap)))
     }
 
     required init?(coder: NSCoder) {
@@ -46,35 +48,29 @@ public final class QuestionOptionLabel: UIView {
 
     // MARK: - Methods
 
+    private func setupUI() {
+        layer.cornerRadius = 16
+        layer.borderWidth = 1
+    }
+
     public func setOptionString(_ str: String) {
-        optionStringLabel.attributedText = formattedText(str)
+        optionStringLabel.attributedText = NSAttributedString(text: str, lineSpacing: 8)
     }
 
     public func setOptionState(isSelected: Bool) {
-        if isSelected {
-            backgroundColor = .customBlue500.withAlphaComponent(0.14)
-            optionNumberLabel.backgroundColor = .customBlue500
-            optionNumberLabel.textColor = .white
-            optionNumberLabel.layer.borderWidth = 0
-        } else {
-            backgroundColor = .white
-            optionNumberLabel.backgroundColor = .white
-            optionNumberLabel.textColor = .coolNeutral700
-            optionNumberLabel.layer.borderWidth = 1.2
-        }
+        let tint: UIColor = isSelected ? .customBlue500 : .coolNeutral100
+        backgroundColor = isSelected ? .customBlue500.withAlphaComponent(0.14) : .white
+        layer.borderColor = tint.cgColor
+        optionNumberLabel.backgroundColor = tint
+        optionNumberLabel.textColor = isSelected ? .white : .coolNeutral400
     }
 
-    private func formattedText(_ text: String) -> NSAttributedString {
-        let attributed = NSMutableAttributedString(string: text)
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineBreakMode = .byTruncatingTail
-        paragraphStyle.lineSpacing = 8
-        attributed.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: attributed.length))
-        return attributed
+    @objc private func handleTap() {
+        onTap?()
     }
 }
 
-// MARK: - Layout
+// MARK: - Layout Setup
 
 extension QuestionOptionLabel {
     private func addSubviews() {
@@ -87,15 +83,17 @@ extension QuestionOptionLabel {
         optionStringLabel.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
-            optionNumberLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
-            optionNumberLabel.widthAnchor.constraint(equalToConstant: 40),
+            optionNumberLabel.topAnchor.constraint(equalTo: topAnchor, constant: 24),
+            optionNumberLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24),
+            optionNumberLabel.widthAnchor.constraint(equalToConstant: 32),
             optionNumberLabel.heightAnchor.constraint(equalTo: optionNumberLabel.widthAnchor),
-            optionNumberLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
 
+            optionStringLabel.topAnchor.constraint(equalTo: topAnchor, constant: 24),
             optionStringLabel.leadingAnchor.constraint(equalTo: optionNumberLabel.trailingAnchor, constant: 16),
-            optionStringLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
-            optionStringLabel.topAnchor.constraint(equalTo: topAnchor, constant: 16),
-            optionStringLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -16)
+            optionStringLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24),
+            optionStringLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -24),
+
+            heightAnchor.constraint(greaterThanOrEqualToConstant: 80),
         ])
     }
 }

--- a/Modules/Core/ExamKit/Sources/ExamKit/QuestionUI/TestContentsView.swift
+++ b/Modules/Core/ExamKit/Sources/ExamKit/QuestionUI/TestContentsView.swift
@@ -8,28 +8,56 @@ import Combine
 import QRIZUtils
 import DesignSystem
 
-public final class TestContentsView: UIStackView {
+public final class TestContentsView: UIView {
 
     // MARK: - Properties
 
+    private let optionTappedSubject = PassthroughSubject<Int, Never>()
+
+    public var optionTappedPublisher: AnyPublisher<Int, Never> {
+        optionTappedSubject.eraseToAnyPublisher()
+    }
+
+    // MARK: - UI
+
+    private let outerStackView: UIStackView = {
+        let sv = UIStackView()
+        sv.axis = .vertical
+        sv.spacing = 12
+        return sv
+    }()
+
+    private let questionCardView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .customBlue50
+        view.layer.cornerRadius = 16
+        return view
+    }()
+
+    private let questionStackView: UIStackView = {
+        let sv = UIStackView()
+        sv.axis = .vertical
+        return sv
+    }()
+
     private let numberLabel: UILabel = {
         let label = UILabel()
-        label.textColor = .black
-        label.font = .boldSystemFont(ofSize: 20)
+        label.textColor = .customBlue500
+        label.font = .systemFont(ofSize: 16, weight: .bold)
         return label
     }()
 
     private let titleLabel: UILabel = {
         let label = UILabel()
-        label.textAlignment = .left
         label.numberOfLines = 0
-        label.textColor = .black
-        label.font = .systemFont(ofSize: 16, weight: .medium)
+        label.textColor = .coolNeutral800
+        label.font = .systemFont(ofSize: 18, weight: .bold)
         return label
     }()
 
     private let descriptionView: UIView = {
         let view = UIView()
+        view.backgroundColor = .white
         view.layer.cornerRadius = 8
         view.layer.masksToBounds = true
         view.layer.borderWidth = 1
@@ -40,34 +68,23 @@ public final class TestContentsView: UIStackView {
     private let descriptionLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
-        label.textAlignment = .left
         label.font = .systemFont(ofSize: 12, weight: .medium)
-        label.textColor = .black
+        label.textColor = .coolNeutral700
         return label
     }()
 
-    private let optionLabels: [QuestionOptionLabel] = (1...4).map {
-        let option = QuestionOptionLabel(number: $0)
-        option.tag = $0
-        return option
-    }
-
-    private let optionTappedSubject: PassthroughSubject<Int, Never> = .init()
-    public var optionTappedPublisher: AnyPublisher<Int, Never> {
-        optionTappedSubject.eraseToAnyPublisher()
-    }
+    private let optionLabels: [QuestionOptionLabel] = (1...4).map { QuestionOptionLabel(number: $0) }
 
     // MARK: - Initialization
 
     public init() {
         super.init(frame: .zero)
-        setupUI()
         addSubviews()
-        setupConstraints()
         setupOptionGestures()
+        setupConstraints()
     }
 
-    required init(coder: NSCoder) {
+    required init?(coder: NSCoder) {
         fatalError("no initializer for coder: TestContentsView")
     }
 
@@ -75,17 +92,12 @@ public final class TestContentsView: UIStackView {
 
     public func updateQuestion(_ question: QuestionData) {
         numberLabel.text = String(format: "%02d.", question.questionNumber)
-        titleLabel.attributedText = lineSpaced(question.question)
-        if let description = question.description {
-            descriptionView.isHidden = false
-            descriptionLabel.attributedText = lineSpaced(description)
-        } else {
-            descriptionView.isHidden = true
-        }
-        let options = [question.option1, question.option2, question.option3, question.option4]
-        optionLabels.forEach {
-            $0.setOptionState(isSelected: false)
-            $0.setOptionString(options[$0.tag - 1])
+        titleLabel.attributedText = NSAttributedString(text: question.question, lineSpacing: 4)
+        descriptionView.isHidden = question.description == nil
+        descriptionLabel.attributedText = question.description.map { NSAttributedString(text: $0, lineSpacing: 4) }
+        optionLabels.enumerated().forEach { index, label in
+            label.setOptionState(isSelected: false)
+            label.setOptionString(question.getOptionRawValue(option: index + 1))
         }
     }
 
@@ -93,59 +105,51 @@ public final class TestContentsView: UIStackView {
         optionLabels[index - 1].setOptionState(isSelected: isSelected)
     }
 
-    private func setupUI() {
-        axis = .vertical
-        alignment = .fill
-        isLayoutMarginsRelativeArrangement = true
-        layoutMargins = UIEdgeInsets(top: 35, left: 0, bottom: 35, right: 0)
-    }
-
-    private func lineSpaced(_ text: String) -> NSMutableAttributedString {
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineSpacing = 4
-        let attributed = NSMutableAttributedString(string: text)
-        attributed.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: attributed.length))
-        return attributed
-    }
-
     private func setupOptionGestures() {
-        optionLabels.forEach {
-            $0.isUserInteractionEnabled = true
-            $0.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(optionTapped(_:))))
+        optionLabels.enumerated().forEach { index, label in
+            label.onTap = { [weak self] in
+                self?.optionTappedSubject.send(index + 1)
+            }
         }
-    }
-
-    @objc private func optionTapped(_ sender: UITapGestureRecognizer) {
-        guard let index = sender.view?.tag else { return }
-        optionTappedSubject.send(index)
     }
 }
 
-// MARK: - Layout
+// MARK: - Layout Setup
 
 extension TestContentsView {
     private func addSubviews() {
-        addArrangedSubview(numberLabel)
-        addArrangedSubview(titleLabel)
-        addArrangedSubview(descriptionView)
+        addSubview(outerStackView)
+        outerStackView.addArrangedSubview(questionCardView)
+        questionCardView.addSubview(questionStackView)
+        [numberLabel, titleLabel, descriptionView].forEach { questionStackView.addArrangedSubview($0) }
         descriptionView.addSubview(descriptionLabel)
-        for option in optionLabels {
-            addArrangedSubview(option)
-        }
+        optionLabels.forEach { outerStackView.addArrangedSubview($0) }
+
+        questionStackView.setCustomSpacing(8, after: numberLabel)
+        questionStackView.setCustomSpacing(16, after: titleLabel)
     }
 
     private func setupConstraints() {
+        outerStackView.translatesAutoresizingMaskIntoConstraints = false
+        questionStackView.translatesAutoresizingMaskIntoConstraints = false
         descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
+            outerStackView.topAnchor.constraint(equalTo: topAnchor),
+            outerStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            outerStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            outerStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            questionStackView.topAnchor.constraint(equalTo: questionCardView.topAnchor, constant: 24),
+            questionStackView.leadingAnchor.constraint(equalTo: questionCardView.leadingAnchor, constant: 24),
+            questionStackView.trailingAnchor.constraint(equalTo: questionCardView.trailingAnchor, constant: -24),
+            questionStackView.bottomAnchor.constraint(equalTo: questionCardView.bottomAnchor, constant: -24),
+
+            descriptionLabel.topAnchor.constraint(equalTo: descriptionView.topAnchor, constant: 16),
             descriptionLabel.leadingAnchor.constraint(equalTo: descriptionView.leadingAnchor, constant: 16),
             descriptionLabel.trailingAnchor.constraint(equalTo: descriptionView.trailingAnchor, constant: -16),
-            descriptionLabel.topAnchor.constraint(equalTo: descriptionView.topAnchor, constant: 16),
-            descriptionLabel.bottomAnchor.constraint(equalTo: descriptionView.bottomAnchor, constant: -16)
+            descriptionLabel.bottomAnchor.constraint(equalTo: descriptionView.bottomAnchor, constant: -16),
         ])
-
-        setCustomSpacing(14, after: numberLabel)
-        setCustomSpacing(14, after: titleLabel)
-        setCustomSpacing(16, after: descriptionView)
     }
 }
+

--- a/Modules/Core/Network/Sources/Network/Base/Network.swift
+++ b/Modules/Core/Network/Sources/Network/Base/Network.swift
@@ -50,7 +50,9 @@ public actor NetworkImpl: Network {
                     where needsAuth && !isRefreshing && code == 3 {
             return try await refreshAndRetry(urlRequest, responseType: T.Response.self)
         } catch {
-            throw mapToNetworkError(error)
+            let networkError = mapToNetworkError(error)
+            logAPIError(networkError, request: urlRequest)
+            throw networkError
         }
     }
 }
@@ -155,7 +157,7 @@ private extension NetworkImpl {
                 message: errorResponse?.msg ?? "클라이언트 에러입니다."
             )
         case 500..<600:
-            throw NetworkError.serverError
+            throw NetworkError.serverError(httpStatus: httpResponse.statusCode)
         default:
             throw NetworkError.unknownError
         }
@@ -167,6 +169,22 @@ private extension NetworkImpl {
         catch { throw NetworkError.jsonDecodingError }
     }
     
+    /// API 에러 Analytics 로깅
+    private func logAPIError(_ error: NetworkError, request: URLRequest) {
+        let endpoint = request.url?.path ?? "unknown"
+        let event: AnalyticsEvent?
+        switch error {
+        case .clientError(let status, _, let message):
+            event = .apiError(endpoint: endpoint, statusCode: status, message: message)
+        case .serverError(let status):
+            event = .apiError(endpoint: endpoint, statusCode: status, message: "서버 에러")
+        default:
+            event = nil
+        }
+        guard let event else { return }
+        Task { @MainActor in AnalyticsManager.shared.log(event) }
+    }
+
     /// Error 매핑
     private func mapToNetworkError(_ error: Error) -> NetworkError {
         switch error {

--- a/Modules/Core/Network/Sources/Network/Base/NetworkError.swift
+++ b/Modules/Core/Network/Sources/Network/Base/NetworkError.swift
@@ -17,7 +17,7 @@ public enum NetworkError: Error, Sendable {
     /// 클라이언트 에러
     case clientError(httpStatus: Int, serverCode: Int?, message: String)
     /// 서버 에러
-    case serverError
+    case serverError(httpStatus: Int)
     /// 알 수 없는 에러
     case unknownError
 }
@@ -33,7 +33,7 @@ extension NetworkError {
             return "접근 권한이 없습니다. detailCode: \(detail.map(String.init) ?? "nil")"
         case .clientError(let httpStatus, let serverCode, let message):
             return "HTTP \(httpStatus), 서버 코드: \(serverCode.map(String.init) ?? "nil"), 메시지: \(message)"
-        case .serverError: return "서버 에러."
+        case .serverError(let httpStatus): return "HTTP \(httpStatus) 서버 에러."
         case .unknownError: return "알 수 없는 오류입니다."
         }
     }

--- a/Modules/Core/QRIZUtils/Sources/QRIZUtils/Manager/AnalyticsService.swift
+++ b/Modules/Core/QRIZUtils/Sources/QRIZUtils/Manager/AnalyticsService.swift
@@ -1,0 +1,29 @@
+//
+//  AnalyticsService.swift
+//  QRIZUtils
+//
+//  Created by 김세훈 on 4/5/26.
+//
+
+@MainActor
+public protocol AnalyticsService: Sendable {
+    func log(_ event: AnalyticsEvent)
+}
+
+@MainActor
+public final class AnalyticsManager: AnalyticsService {
+
+    public static let shared = AnalyticsManager()
+
+    private var service: (any AnalyticsService)?
+
+    private init() {}
+
+    public func configure(service: any AnalyticsService) {
+        self.service = service
+    }
+
+    public func log(_ event: AnalyticsEvent) {
+        service?.log(event)
+    }
+}

--- a/Modules/Core/QRIZUtils/Sources/QRIZUtils/Manager/AnalyticsService.swift
+++ b/Modules/Core/QRIZUtils/Sources/QRIZUtils/Manager/AnalyticsService.swift
@@ -13,11 +13,11 @@ public protocol AnalyticsService: Sendable {
 @MainActor
 public final class AnalyticsManager: AnalyticsService {
 
-    public static let shared = AnalyticsManager()
+    public nonisolated static let shared = AnalyticsManager()
 
     private var service: (any AnalyticsService)?
 
-    private init() {}
+    private nonisolated init() {}
 
     public func configure(service: any AnalyticsService) {
         self.service = service

--- a/Modules/Core/QRIZUtils/Sources/QRIZUtils/Types/AnalyticsEvent.swift
+++ b/Modules/Core/QRIZUtils/Sources/QRIZUtils/Types/AnalyticsEvent.swift
@@ -1,0 +1,58 @@
+//
+//  AnalyticsEvent.swift
+//  QRIZUtils
+//
+//  Created by 김세훈 on 4/5/26.
+//
+
+public enum AnalyticsEvent: Sendable {
+
+    // MARK: - Screen
+
+    case screenView(ScreenName)
+
+    // MARK: - Auth
+
+    case login(LoginMethod)
+    case logout
+
+    // MARK: - Exam
+
+    case examStart
+    case examComplete(score: Int, total: Int)
+    case examAbandon
+
+    // MARK: - Daily
+
+    case dailyComplete
+
+    // MARK: - API
+
+    case apiError(endpoint: String, statusCode: Int, message: String)
+}
+
+// MARK: - Nested Types
+
+public extension AnalyticsEvent {
+    enum ScreenName: String, Sendable {
+        case login
+        case home
+        case examList = "exam_list"
+        case examTest = "exam_test"
+        case examResult = "exam_result"
+        case examSummary = "exam_summary"
+        case daily
+        case conceptBook = "concept_book"
+        case myPage = "my_page"
+        case onboarding
+        case mistakeNote = "mistake_note"
+    }
+
+    enum LoginMethod: String, Sendable {
+        case email
+        case kakao
+        case google
+        case apple
+        case unknown
+    }
+}

--- a/Modules/Features/Account/Sources/Account/Login/ViewController/LoginViewController.swift
+++ b/Modules/Features/Account/Sources/Account/Login/ViewController/LoginViewController.swift
@@ -40,6 +40,7 @@ final class LoginViewController: UIViewController {
         super.viewDidLoad()
         bind()
         observe()
+        AnalyticsManager.shared.log(.screenView(.login))
     }
 
     // MARK: - Methods

--- a/Modules/Features/Account/Sources/Account/Login/ViewModel/LoginViewModel.swift
+++ b/Modules/Features/Account/Sources/Account/Login/ViewModel/LoginViewModel.swift
@@ -31,14 +31,18 @@ final class LoginViewModel {
 
     // MARK: - Initialization
 
+    private let analyticsService: any AnalyticsService
+
     init(
         loginService: LoginService,
         userInfoService: UserInfoService,
-        socialLoginService: SocialLoginService
+        socialLoginService: SocialLoginService,
+        analyticsService: any AnalyticsService = AnalyticsManager.shared
     ) {
         self.loginService = loginService
         self.userInfoService = userInfoService
         self.socialLoginService = socialLoginService
+        self.analyticsService = analyticsService
     }
 
     // MARK: - Methods
@@ -94,6 +98,7 @@ final class LoginViewModel {
                 let response = try await loginService.login(id: id, password: password)
                 let user = response.data.user
                 UserInfoManager.shared.update(name: user.name, userId: user.userId, email: user.email, previewTestStatus: user.previewTestStatus, provider: user.provider)
+                analyticsService.log(.login(.email))
                 outputSubject.send(.loginSucceeded)
             } catch {
                 outputSubject.send(.showErrorAlert(title: "아이디 또는 비밀번호 확인", description: "아이디와 비밀번호를 정확하게 입력해 주세요."))
@@ -139,6 +144,7 @@ final class LoginViewModel {
                     previewTestStatus: user.previewTestStatus,
                     provider: user.provider
                 )
+                analyticsService.log(.login(loginMethod(from: providerName)))
                 outputSubject.send(.loginSucceeded)
             } catch let error as SocialAuthError where error == .cancelled {
                 logger.info("\(providerName) login canceled by user.")
@@ -146,6 +152,17 @@ final class LoginViewModel {
                 outputSubject.send(.showErrorAlert(title: "\(providerName) 로그인 실패", description: "잠시 후 다시 시도해 주세요."))
                 logger.error("\(providerName) social login failed: \(String(describing: error), privacy: .public)")
             }
+        }
+    }
+
+    private func loginMethod(from providerName: String) -> AnalyticsEvent.LoginMethod {
+        switch providerName {
+        case "카카오": return .kakao
+        case "구글": return .google
+        case "애플": return .apple
+        default:
+            logger.warning("알 수 없는 소셜 로그인 provider: \(providerName, privacy: .public)")
+            return .unknown
         }
     }
 }

--- a/Modules/Features/Daily/Sources/Daily/DailyLearn/ViewModel/DailyLearnViewModel.swift
+++ b/Modules/Features/Daily/Sources/Daily/DailyLearn/ViewModel/DailyLearnViewModel.swift
@@ -99,7 +99,7 @@ final class DailyLearnViewModel {
 
                 output.send(.fetchSuccess(state: state, type: type, score: score))
                 output.send(.updateContent(concepts: concepts))
-            } catch NetworkError.serverError {
+            } catch NetworkError.serverError(_) {
                 output.send(.fetchFailed(isServerError: true))
             } catch {
                 output.send(.fetchFailed(isServerError: false))

--- a/Modules/Features/Daily/Sources/Daily/DailyResult/ViewModel/DailyResultViewModel.swift
+++ b/Modules/Features/Daily/Sources/Daily/DailyResult/ViewModel/DailyResultViewModel.swift
@@ -109,7 +109,7 @@ final class DailyResultViewModel: ObservableObject {
                 try await fetchDailyAndComprehensiveResult()
             }
             updateData()
-        } catch NetworkError.serverError {
+        } catch NetworkError.serverError(_) {
             errorMessage = "관리자에게 문의하세요."
         } catch {
             errorMessage = "잠시 후 다시 시도해주세요."

--- a/Modules/Features/Daily/Sources/Daily/DailyTest/View/DailyTestView.swift
+++ b/Modules/Features/Daily/Sources/Daily/DailyTest/View/DailyTestView.swift
@@ -129,8 +129,8 @@ extension DailyTestView {
 
             contentsView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
             contentsView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
-            contentsView.topAnchor.constraint(equalTo: scrollView.topAnchor),
-            contentsView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            contentsView.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: 32),
+            contentsView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: -32),
             contentsView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
         ])
     }

--- a/Modules/Features/Daily/Sources/Daily/DailyTest/ViewController/DailyTestViewController.swift
+++ b/Modules/Features/Daily/Sources/Daily/DailyTest/ViewController/DailyTestViewController.swift
@@ -52,6 +52,11 @@ final class DailyTestViewController: UIViewController {
         input.send(.viewDidLoad)
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: animated)
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         input.send(.viewDidAppear)

--- a/Modules/Features/Daily/Sources/Daily/DailyTest/ViewModel/DailyTestViewModel.swift
+++ b/Modules/Features/Daily/Sources/Daily/DailyTest/ViewModel/DailyTestViewModel.swift
@@ -57,12 +57,18 @@ final class DailyTestViewModel {
     private var subscriptions = Set<AnyCancellable>()
     
     private let dailyService: DailyService
-    
+    private let analyticsService: any AnalyticsService
+
     // MARK: - Initializers
-    
-    init(day: Int, dailyService: DailyService) {
+
+    init(
+        day: Int,
+        dailyService: DailyService,
+        analyticsService: any AnalyticsService = AnalyticsManager.shared
+    ) {
         self.day = day
         self.dailyService = dailyService
+        self.analyticsService = analyticsService
     }
     
     // MARK: - Deinitializer
@@ -128,7 +134,7 @@ final class DailyTestViewModel {
                 curNum = 1
                 output.send(.updateTotalPage(totalPage: questionList.count))
                 questionStateHandler()
-            } catch NetworkError.serverError {
+            } catch NetworkError.serverError(_) {
                 output.send(.fetchFailed(isServerError: true))
             } catch {
                 output.send(.fetchFailed(isServerError: false))
@@ -205,6 +211,7 @@ final class DailyTestViewModel {
             do {
                 try await dailyService.submitDaily(dayNumber: day, dailySubmitData: submitData)
                 exitTimer()
+                analyticsService.log(.dailyComplete)
                 output.send(.submitSuccess)
                 output.send(.moveToDailyResult)
             } catch {

--- a/Modules/Features/Exam/Sources/Exam/Coordinator/ExamCoordinatorImpl.swift
+++ b/Modules/Features/Exam/Sources/Exam/Coordinator/ExamCoordinatorImpl.swift
@@ -39,6 +39,7 @@ final class ExamCoordinatorImpl: ExamNavigating, NavigationGuard {
         guardNavigation {
             let vm = ExamListViewModel(examService: self.service)
             let vc = ExamListViewController(viewModel: vm, coordinator: self)
+            vc.hidesBottomBarWhenPushed = true
             self.examListViewController = vc
             self.navigationController.pushViewController(vc, animated: true)
         }

--- a/Modules/Features/Exam/Sources/Exam/ExamResult/ViewModel/ExamResultViewModel.swift
+++ b/Modules/Features/Exam/Sources/Exam/ExamResult/ViewModel/ExamResultViewModel.swift
@@ -51,12 +51,18 @@ final class ExamResultViewModel: ObservableObject {
     private let nickname = UserInfoManager.shared.name
     private let examId: Int
     private let examService: any ExamService
+    private let analyticsService: any AnalyticsService
 
     // MARK: - Initialization
 
-    init(examId: Int, examService: any ExamService) {
+    init(
+        examId: Int,
+        examService: any ExamService,
+        analyticsService: any AnalyticsService = AnalyticsManager.shared
+    ) {
         self.examId = examId
         self.examService = examService
+        self.analyticsService = analyticsService
     }
 
     // MARK: - Methods
@@ -104,7 +110,7 @@ final class ExamResultViewModel: ObservableObject {
             updateData()
         } catch is CancellationError {
             return
-        } catch NetworkError.serverError {
+        } catch NetworkError.serverError(_) {
             errorMessage = "관리자에게 문의하세요."
         } catch {
             errorMessage = "잠시 후 다시 시도해주세요."
@@ -160,6 +166,8 @@ final class ExamResultViewModel: ObservableObject {
             self.resultScoresData.subjectCount = self.subjectCount
 
             self.resultGradeListData.gradeResultList = self.gradeResultList
+            let score = self.gradeResultList.filter { $0.correction }.count
+            self.analyticsService.log(.examComplete(score: score, total: self.gradeResultList.count))
 
             self.resultDetailData.subject1DetailResult = self.subject1DetailResult
             self.resultDetailData.subject2DetailResult = self.subject2DetailResult

--- a/Modules/Features/Exam/Sources/Exam/ExamTest/View/ExamTestView.swift
+++ b/Modules/Features/Exam/Sources/Exam/ExamTest/View/ExamTestView.swift
@@ -143,8 +143,8 @@ extension ExamTestView {
 
             contentsView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
             contentsView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
-            contentsView.topAnchor.constraint(equalTo: scrollView.topAnchor),
-            contentsView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            contentsView.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: 32),
+            contentsView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: -32),
             contentsView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
         ])
     }

--- a/Modules/Features/Exam/Sources/Exam/ExamTest/ViewController/ExamTestViewController.swift
+++ b/Modules/Features/Exam/Sources/Exam/ExamTest/ViewController/ExamTestViewController.swift
@@ -42,6 +42,7 @@ final class ExamTestViewController: UIViewController {
         bind()
         setupNavigationItems()
         setupAlertButtonActions()
+        AnalyticsManager.shared.log(.screenView(.examTest))
         inputSubject.send(.viewDidLoad)
     }
 

--- a/Modules/Features/Exam/Sources/Exam/ExamTest/ViewController/ExamTestViewController.swift
+++ b/Modules/Features/Exam/Sources/Exam/ExamTest/ViewController/ExamTestViewController.swift
@@ -46,6 +46,11 @@ final class ExamTestViewController: UIViewController {
         inputSubject.send(.viewDidLoad)
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: animated)
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         inputSubject.send(.viewDidAppear)

--- a/Modules/Features/Exam/Sources/Exam/ExamTest/ViewModel/ExamTestViewModel.swift
+++ b/Modules/Features/Exam/Sources/Exam/ExamTest/ViewModel/ExamTestViewModel.swift
@@ -24,9 +24,16 @@ final class ExamTestViewModel {
 
     // MARK: - Initialization
 
-    init(examId: Int, examService: any ExamService) {
+    private let analyticsService: any AnalyticsService
+
+    init(
+        examId: Int,
+        examService: any ExamService,
+        analyticsService: any AnalyticsService = AnalyticsManager.shared
+    ) {
         self.examId = examId
         self.examService = examService
+        self.analyticsService = analyticsService
     }
 
     // MARK: - Methods
@@ -47,6 +54,7 @@ final class ExamTestViewModel {
                     handleOptionSelect(optionIdx: optionIdx)
 
                 case .didTapCancelButton:
+                    analyticsService.log(.examAbandon)
                     countdown?.stop()
                     outputSubject.send(.moveToExamList)
 
@@ -99,8 +107,9 @@ final class ExamTestViewModel {
                 outputSubject.send(.updateTotalPage(totalPage: questionList.count))
                 updateQuestionState()
                 setupCountdown(totalTime: data.totalTimeLimit)
+                analyticsService.log(.examStart)
 
-            } catch NetworkError.serverError {
+            } catch NetworkError.serverError(_) {
                 outputSubject.send(.fetchFailed(isServerError: true))
 
             } catch {

--- a/Modules/Features/Home/Sources/Home/ViewModel/HomeViewModel.swift
+++ b/Modules/Features/Home/Sources/Home/ViewModel/HomeViewModel.swift
@@ -27,9 +27,13 @@ final class HomeViewModel {
     
     // MARK: - Initialization
 
-    init(examScheduleService: ExamScheduleService,
-         dailyService: DailyService,
-         weeklyService: WeeklyRecommendService
+    private let analyticsService: any AnalyticsService
+
+    init(
+        examScheduleService: ExamScheduleService,
+        dailyService: DailyService,
+        weeklyService: WeeklyRecommendService,
+        analyticsService: any AnalyticsService = AnalyticsManager.shared
     ) {
         let name = UserInfoManager.shared.name
         let previewStatus = UserInfoManager.shared.previewTestStatus
@@ -51,6 +55,7 @@ final class HomeViewModel {
         self.examScheduleService = examScheduleService
         self.dailyService = dailyService
         self.weeklyService = weeklyService
+        self.analyticsService = analyticsService
         self.state = initState
     }
 
@@ -62,6 +67,7 @@ final class HomeViewModel {
                 guard let self else { return }
                 switch event {
                 case .viewDidLoad:
+                    analyticsService.log(.screenView(.home))
                     Task { [self] in await self.loadAllData() }
 
                 case .entryTapped:

--- a/Modules/Features/MistakeNote/Sources/MistakeNote/MistakeNoteList/ViewController/MistakeNoteViewController.swift
+++ b/Modules/Features/MistakeNote/Sources/MistakeNote/MistakeNoteList/ViewController/MistakeNoteViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 import DesignSystem
 import SwiftUI
+import QRIZUtils
 
 @MainActor
 public final class MistakeNoteViewController: UIHostingController<MistakeNoteMainView> {
@@ -33,6 +34,7 @@ public final class MistakeNoteViewController: UIHostingController<MistakeNoteMai
     override public func viewDidLoad() {
         super.viewDidLoad()
         configureNavigationTitle()
+        AnalyticsManager.shared.log(.screenView(.mistakeNote))
     }
 
     override public func viewWillAppear(_ animated: Bool) {

--- a/Modules/Features/MyPage/Sources/MyPage/DeleteAccount/ViewModel/DeleteAccountViewModel.swift
+++ b/Modules/Features/MyPage/Sources/MyPage/DeleteAccount/ViewModel/DeleteAccountViewModel.swift
@@ -68,7 +68,6 @@ final class DeleteAccountViewModel {
     private func deleteByProvider(_ provider: SocialLogin) async throws {
         switch provider {
         case .kakao:
-            try await socialLoginService.unlinkKakao()
             _ = try await myPageService.deleteSocialAccount(socialLoginType: .kakao)
         case .google:
             _ = try await myPageService.deleteSocialAccount(socialLoginType: .google)

--- a/Modules/Features/MyPage/Sources/MyPage/MyPage/ViewModel/MyPageViewModel.swift
+++ b/Modules/Features/MyPage/Sources/MyPage/MyPage/ViewModel/MyPageViewModel.swift
@@ -18,9 +18,16 @@ final class MyPageViewModel {
 
     // MARK: - Initialization
 
-    init(userName: String, myPageService: any MyPageService) {
+    private let analyticsService: any AnalyticsService
+
+    init(
+        userName: String,
+        myPageService: any MyPageService,
+        analyticsService: any AnalyticsService = AnalyticsManager.shared
+    ) {
         self.userName = userName
         self.myPageService = myPageService
+        self.analyticsService = analyticsService
     }
 
     // MARK: - Methods
@@ -31,6 +38,7 @@ final class MyPageViewModel {
                 guard let self else { return }
                 switch event {
                 case .viewDidLoad:
+                    analyticsService.log(.screenView(.myPage))
                     self.fetchVersion()
 
                 case .didTapProfile:

--- a/Modules/Features/MyPage/Tests/MyPageTests/UnitTests/DeleteAccountViewModelTests.swift
+++ b/Modules/Features/MyPage/Tests/MyPageTests/UnitTests/DeleteAccountViewModelTests.swift
@@ -47,11 +47,9 @@ struct DeleteAccountViewModelTests {
 
     // MARK: - didConfirmDelete
 
-    @Test("didConfirmDelete kakao 성공 → unlinkKakao 호출 후 deletionSucceeded emit")
+    @Test("didConfirmDelete kakao 성공 → deletionSucceeded emit")
     func didConfirmDelete_kakao_emitsDeletionSucceeded() async throws {
-        // kakao: unlinkKakao() + deleteSocialAccount(.kakao) 순서로 호출
-        let socialLoginService = MockSocialLoginService()
-        let sut = makeSUT(provider: "kakao", socialLoginService: socialLoginService)
+        let sut = makeSUT(provider: "kakao")
         let inputSubject = PassthroughSubject<DeleteAccountViewModel.Input, Never>()
         var received: [DeleteAccountViewModel.Output] = []
         var cancellables = Set<AnyCancellable>()
@@ -62,8 +60,6 @@ struct DeleteAccountViewModelTests {
 
         inputSubject.send(.didConfirmDelete)
         try await Task.sleep(nanoseconds: asyncSleepNanoseconds)
-
-        #expect(socialLoginService.unlinkKakaoCallCount == 1)
 
         guard received.count == 1, let first = received.first else {
             Issue.record("Expected 1 output, got \(received.count): \(received)")
@@ -150,7 +146,6 @@ struct DeleteAccountViewModelTests {
 
     @Test("didConfirmDelete NetworkError 실패 → showErrorAlert emit")
     func didConfirmDelete_networkError_emitsShowErrorAlert() async throws {
-        // kakao provider: unlinkKakao 성공 유지, deleteSocialAccount만 NetworkError 실패
         let myPageService = MockMyPageService()
         myPageService.deleteSocialAccountResult = .failure(NetworkError.serverError)
         let sut = makeSUT(provider: "kakao", myPageService: myPageService)
@@ -204,58 +199,4 @@ struct DeleteAccountViewModelTests {
         #expect(message == "잠시 후 다시 시도해 주세요.")
     }
 
-    @Test("didConfirmDelete kakao unlinkKakao NetworkError 실패 → showErrorAlert emit")
-    func didConfirmDelete_kakaoUnlinkNetworkError_emitsShowErrorAlert() async throws {
-        // kakao: unlinkKakao() 자체가 NetworkError로 실패하는 경우
-        let socialLoginService = MockSocialLoginService()
-        socialLoginService.unlinkKakaoResult = .failure(NetworkError.serverError)
-        let sut = makeSUT(provider: "kakao", socialLoginService: socialLoginService)
-        let inputSubject = PassthroughSubject<DeleteAccountViewModel.Input, Never>()
-        var received: [DeleteAccountViewModel.Output] = []
-        var cancellables = Set<AnyCancellable>()
-
-        sut.transform(input: inputSubject.eraseToAnyPublisher())
-            .sink { received.append($0) }
-            .store(in: &cancellables)
-
-        inputSubject.send(.didConfirmDelete)
-        try await Task.sleep(nanoseconds: asyncSleepNanoseconds)
-
-        guard received.count == 1, let first = received.first else {
-            Issue.record("Expected 1 output, got \(received.count): \(received)")
-            return
-        }
-        guard case .showErrorAlert(let message) = first else {
-            Issue.record("Expected .showErrorAlert, got \(first)")
-            return
-        }
-        #expect(message == NetworkError.serverError.errorMessage)
-    }
-
-    @Test("didConfirmDelete kakao unlinkKakao 일반 Error 실패 → showErrorAlert emit")
-    func didConfirmDelete_kakaoUnlinkGenericError_emitsShowErrorAlert() async throws {
-        let socialLoginService = MockSocialLoginService()
-        socialLoginService.unlinkKakaoResult = .failure(URLError(.notConnectedToInternet))
-        let sut = makeSUT(provider: "kakao", socialLoginService: socialLoginService)
-        let inputSubject = PassthroughSubject<DeleteAccountViewModel.Input, Never>()
-        var received: [DeleteAccountViewModel.Output] = []
-        var cancellables = Set<AnyCancellable>()
-
-        sut.transform(input: inputSubject.eraseToAnyPublisher())
-            .sink { received.append($0) }
-            .store(in: &cancellables)
-
-        inputSubject.send(.didConfirmDelete)
-        try await Task.sleep(nanoseconds: asyncSleepNanoseconds)
-
-        guard received.count == 1, let first = received.first else {
-            Issue.record("Expected 1 output, got \(received.count): \(received)")
-            return
-        }
-        guard case .showErrorAlert(let message) = first else {
-            Issue.record("Expected .showErrorAlert, got \(first)")
-            return
-        }
-        #expect(message == "잠시 후 다시 시도해 주세요.")
-    }
 }

--- a/Modules/Features/Onboarding/Sources/Onboarding/CheckConcept/View/CheckConceptView.swift
+++ b/Modules/Features/Onboarding/Sources/Onboarding/CheckConcept/View/CheckConceptView.swift
@@ -1,19 +1,14 @@
 import SwiftUI
 import DesignSystem
+import Network
+import QRIZUtils
 
 struct CheckConceptView: View {
 
     // MARK: - Properties
 
     @ObservedObject var viewModel: CheckConceptViewModel
-    @State private var expandedSections: Set<Int>
-
-    // MARK: - Initializer
-
-    init(viewModel: CheckConceptViewModel) {
-        self.viewModel = viewModel
-        _expandedSections = State(initialValue: Set(0..<viewModel.sections.count))
-    }
+    @State private var isExpanded: Bool = true
 
     // MARK: - Body
 
@@ -66,11 +61,11 @@ private extension CheckConceptView {
     var clearAllButton: some View {
         Button(action: { viewModel.didTapNone() }) {
             HStack {
-                Image(systemName: viewModel.selectedSet.isEmpty ? "checkmark.square.fill" : "square")
-                    .foregroundColor(viewModel.selectedSet.isEmpty ? Color.customBlue500 : Color.coolNeutral400)
-                    .font(.system(size: 20))
-                Text("전체 해제")
-                    .font(.system(size: 14))
+                Image(uiImage: viewModel.selectedSet.isEmpty ? .checkboxOnIcon : .checkboxOffIcon)
+                    .resizable()
+                    .frame(width: 24, height: 24)
+                Text("모든 개념을 처음 봐요")
+                    .font(.system(size: 16, weight: .medium))
                     .foregroundColor(Color.coolNeutral800)
                 Spacer()
             }
@@ -86,7 +81,7 @@ private extension CheckConceptView {
     var divider: some View {
         Divider()
             .background(Color.customBlue100)
-            .frame(height: 2)
+            .frame(height: 1)
             .padding(.horizontal, 18)
             .padding(.top, 16)
     }
@@ -95,63 +90,46 @@ private extension CheckConceptView {
         HStack {
             Button(action: { viewModel.didTapAll() }) {
                 HStack(spacing: 12) {
-                    Image(systemName: viewModel.isAllSelected ? "checkmark.square.fill" : "square")
-                        .foregroundColor(viewModel.isAllSelected ? Color.customBlue500 : Color.coolNeutral400)
-                        .font(.system(size: 20))
-                    Text("전체 선택")
-                        .font(.system(size: 14))
+                    Image(uiImage: viewModel.isAllSelected ? .checkboxOnIcon : (viewModel.selectedSet.isEmpty ? .checkboxOffIcon : .checkboxSomeIcon))
+                        .resizable()
+                        .frame(width: 24, height: 24)
+                    Text("전부 아는 개념이에요!")
+                        .font(.system(size: 16, weight: .medium))
                         .foregroundColor(Color.coolNeutral800)
                     Spacer()
                 }
             }
             .buttonStyle(.plain)
 
-            Button(action: { toggleAllSections() }) {
-                Image(systemName: expandedSections.isEmpty ? "chevron.down" : "chevron.up")
+            Button(action: { isExpanded.toggle() }) {
+                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
                     .foregroundColor(Color.coolNeutral600)
                     .font(.system(size: 16))
                     .frame(width: 40, height: 40)
             }
         }
-        .padding(.horizontal, 18)
+        .padding(.horizontal, 16)
         .frame(height: 60)
-        .padding(.top, 16)
+        .background(Color.white)
+        .padding(.horizontal, 18)
+        .padding(.vertical, 16)
     }
 
     var conceptList: some View {
         ScrollView {
-            LazyVStack(spacing: 0) {
-                ForEach(viewModel.sections.indices, id: \.self) { sectionIdx in
-                    let section = viewModel.sections[sectionIdx]
-                    DisclosureGroup(
-                        isExpanded: Binding(
-                            get: { expandedSections.contains(sectionIdx) },
-                            set: { expanded in
-                                if expanded { expandedSections.insert(sectionIdx) }
-                                else { expandedSections.remove(sectionIdx) }
-                            }
-                        ),
-                        content: {
-                            ForEach(section.range, id: \.self) { globalIdx in
-                                ConceptRowView(
-                                    title: viewModel.title(for: globalIdx),
-                                    isSelected: viewModel.selectedSet.contains(globalIdx),
-                                    action: { viewModel.didTapConcept(at: globalIdx) }
-                                )
-                            }
-                        },
-                        label: {
-                            Text(section.title)
-                                .font(.system(size: 14, weight: .medium))
-                                .foregroundColor(Color.coolNeutral700)
-                                .padding(.leading, 24)
-                        }
-                    )
-                    .padding(.horizontal, 18)
-                    .accentColor(Color.coolNeutral600)
+            if isExpanded {
+                LazyVStack(spacing: 0) {
+                    ForEach(viewModel.allConceptIndices, id: \.self) { idx in
+                        ConceptRowView(
+                            title: viewModel.title(for: idx),
+                            isSelected: viewModel.selectedSet.contains(idx),
+                            action: { viewModel.didTapConcept(at: idx) }
+                        )
+                    }
                 }
+                .padding(.leading, 30)
+                .padding(.bottom, 80)
             }
-            .padding(.bottom, 80)
         }
         .background(Color.customBlue50)
     }
@@ -180,15 +158,20 @@ private extension CheckConceptView {
     }
 }
 
-// MARK: - Private Methods
+// MARK: - Preview
 
-private extension CheckConceptView {
+private struct PreviewOnboardingService: OnboardingService {
+    func sendSurvey(keyConcepts: [String]) async throws {}
+    func getPreviewTestList() async throws -> PreviewTestListResponse { fatalError() }
+    func submitPreview(testSubmitDataList: [TestSubmitData]) async throws -> PreviewSubmitResponse { fatalError() }
+    func analyzePreview() async throws -> AnalyzePreviewResponse { fatalError() }
+}
 
-    func toggleAllSections() {
-        if expandedSections.isEmpty {
-            expandedSections = Set(0..<viewModel.sections.count)
-        } else {
-            expandedSections.removeAll()
-        }
-    }
+#Preview {
+    CheckConceptView(
+        viewModel: CheckConceptViewModel(
+            onboardingService: PreviewOnboardingService(),
+            onNavigate: { _ in }
+        )
+    )
 }

--- a/Modules/Features/Onboarding/Sources/Onboarding/CheckConcept/View/ConceptRowView.swift
+++ b/Modules/Features/Onboarding/Sources/Onboarding/CheckConcept/View/ConceptRowView.swift
@@ -37,8 +37,8 @@ struct ConceptRowView: View {
 private extension ConceptRowView {
 
     var checkboxIcon: some View {
-        Image(systemName: isSelected ? "checkmark.square.fill" : "square")
-            .foregroundColor(isSelected ? Color.customBlue500 : Color.coolNeutral400)
-            .font(.system(size: 20))
+        Image(uiImage: isSelected ? .checkboxOnIcon : .checkboxOffIcon)
+            .resizable()
+            .frame(width: 24, height: 24)
     }
 }

--- a/Modules/Features/Onboarding/Sources/Onboarding/CheckConcept/ViewModel/CheckConceptViewModel.swift
+++ b/Modules/Features/Onboarding/Sources/Onboarding/CheckConcept/ViewModel/CheckConceptViewModel.swift
@@ -29,6 +29,10 @@ final class CheckConceptViewModel: ObservableObject {
         selectedSet.count == totalConceptCount
     }
 
+    var allConceptIndices: Range<Int> {
+        0..<totalConceptCount
+    }
+
     private let onNavigate: (CheckConceptNavigation) -> Void
     private let onboardingService: OnboardingService
 

--- a/Modules/Features/Onboarding/Sources/Onboarding/Coordinator/OnboardingCoordinatorImpl.swift
+++ b/Modules/Features/Onboarding/Sources/Onboarding/Coordinator/OnboardingCoordinatorImpl.swift
@@ -54,6 +54,7 @@ final class OnboardingCoordinatorImpl: OnboardingNavigating, NavigationGuard {
         guardNavigation {
             let vm = BeginOnboardingViewModel(onNavigate: { [weak self] in self?.showCheckConcept() })
             let vc = UIHostingController(rootView: BeginOnboardingView(viewModel: vm))
+            vc.hidesBottomBarWhenPushed = true
             navigationController.pushViewController(vc, animated: true)
         }
     }
@@ -78,6 +79,7 @@ final class OnboardingCoordinatorImpl: OnboardingNavigating, NavigationGuard {
         guardNavigation {
             let vm = BeginPreviewTestViewModel(onNavigate: { [weak self] in self?.showPreviewTest() })
             let vc = UIHostingController(rootView: BeginPreviewTestView(viewModel: vm))
+            vc.hidesBottomBarWhenPushed = true
             navigationController.pushViewController(vc, animated: true)
         }
     }

--- a/Modules/Features/Onboarding/Sources/Onboarding/PreviewTest/View/PreviewTestView.swift
+++ b/Modules/Features/Onboarding/Sources/Onboarding/PreviewTest/View/PreviewTestView.swift
@@ -1,8 +1,24 @@
 import UIKit
+import Combine
 import DesignSystem
 import ExamKit
+import QRIZUtils
 
 final class PreviewTestView: UIView {
+
+    // MARK: - Metric
+
+    private enum Metric {
+        static let progressBarHeight: CGFloat = 4
+        static let footerHeight: CGFloat = 108
+        static let scrollInset: CGFloat = 18
+    }
+
+    // MARK: - Properties
+
+    var optionTappedPublisher: AnyPublisher<Int, Never> {
+        contentsView.optionTappedPublisher
+    }
 
     // MARK: - UI
 
@@ -12,24 +28,6 @@ final class PreviewTestView: UIView {
         view.trackTintColor = .coolNeutral200
         return view
     }()
-
-    let questionNumberLabel: UILabel = {
-        let label = UILabel()
-        label.textColor = .black
-        label.font = .boldSystemFont(ofSize: 20)
-        return label
-    }()
-
-    let questionTitleLabel: UILabel = {
-        let label = UILabel()
-        label.textAlignment = .left
-        label.numberOfLines = 0
-        label.textColor = .black
-        label.font = .systemFont(ofSize: 16, weight: .medium)
-        return label
-    }()
-
-    let optionLabels: [QuestionOptionLabel] = (1...4).map { QuestionOptionLabel(number: $0) }
 
     let cancelButton: UIButton = {
         let button = UIButton(type: .system)
@@ -55,6 +53,14 @@ final class PreviewTestView: UIView {
         return label
     }()
 
+    private let scrollView: UIScrollView = {
+        let sv = UIScrollView()
+        sv.backgroundColor = .white
+        return sv
+    }()
+
+    private let contentsView = TestContentsView()
+
     private let pageIndicatorBgView: UIView = {
         let view = UIView()
         view.backgroundColor = .white
@@ -72,9 +78,9 @@ final class PreviewTestView: UIView {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        backgroundColor = .white
         addSubviews()
         setupConstraints()
-        setupUI()
     }
 
     required init?(coder: NSCoder) {
@@ -83,71 +89,55 @@ final class PreviewTestView: UIView {
 
     // MARK: - Methods
 
-    private func setupUI() {
-        backgroundColor = .white
+    func updateQuestion(_ question: QuestionData) {
+        contentsView.updateQuestion(question)
+        scrollView.setContentOffset(.zero, animated: false)
+    }
+
+    func updateOptionState(at index: Int, isSelected: Bool) {
+        contentsView.setOptionState(at: index, isSelected: isSelected)
+    }
+
+    func updateProgress(timeLimit: Int, timeRemaining: Int) {
+        progressView.progress = Float(timeRemaining) / Float(timeLimit)
+        timeLabel.text = timeRemaining.formattedTime
     }
 }
 
 // MARK: - Layout Setup
 
 private extension PreviewTestView {
-    private func addSubviews() {
-        let views: [UIView] = [
-            progressView, questionNumberLabel, questionTitleLabel,
-            pageIndicatorBgView, previousButton, nextButton, pageIndicatorLabel
-        ] + optionLabels
-        views.forEach {
+    func addSubviews() {
+        [progressView, scrollView, pageIndicatorBgView, previousButton, nextButton, pageIndicatorLabel].forEach {
             addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
+        scrollView.addSubview(contentsView)
+        contentsView.translatesAutoresizingMaskIntoConstraints = false
     }
 
-    private func setupConstraints() {
-        setupProgressViewConstraints()
-        setupQuestionSectionConstraints()
-        setupOptionLabelsConstraints()
-        setupBottomSectionConstraints()
-    }
-
-    private func setupProgressViewConstraints() {
+    func setupConstraints() {
         NSLayoutConstraint.activate([
             progressView.leadingAnchor.constraint(equalTo: leadingAnchor),
             progressView.trailingAnchor.constraint(equalTo: trailingAnchor),
             progressView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
-            progressView.heightAnchor.constraint(equalToConstant: 4)
-        ])
-    }
+            progressView.heightAnchor.constraint(equalToConstant: Metric.progressBarHeight),
 
-    private func setupQuestionSectionConstraints() {
-        NSLayoutConstraint.activate([
-            questionNumberLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 18),
-            questionNumberLabel.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 40),
-
-            questionTitleLabel.leadingAnchor.constraint(equalTo: questionNumberLabel.leadingAnchor),
-            questionTitleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -18),
-            questionTitleLabel.topAnchor.constraint(equalTo: questionNumberLabel.bottomAnchor, constant: 14)
-        ])
-    }
-
-    private func setupOptionLabelsConstraints() {
-        optionLabels.forEach {
-            NSLayoutConstraint.activate([
-                $0.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 18),
-                $0.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -18)
-            ])
-        }
-        optionLabels.first?.topAnchor.constraint(equalTo: questionTitleLabel.bottomAnchor, constant: 26).isActive = true
-        zip(optionLabels, optionLabels.dropFirst()).forEach { prev, curr in
-            curr.topAnchor.constraint(equalTo: prev.bottomAnchor).isActive = true
-        }
-    }
-
-    private func setupBottomSectionConstraints() {
-        NSLayoutConstraint.activate([
             pageIndicatorBgView.leadingAnchor.constraint(equalTo: leadingAnchor),
             pageIndicatorBgView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            pageIndicatorBgView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -108),
+            pageIndicatorBgView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -Metric.footerHeight),
             pageIndicatorBgView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Metric.scrollInset),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Metric.scrollInset),
+            scrollView.topAnchor.constraint(equalTo: progressView.bottomAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: pageIndicatorBgView.topAnchor),
+
+            contentsView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentsView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            contentsView.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: 32),
+            contentsView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: -32),
+            contentsView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
 
             previousButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 18),
             previousButton.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -30),
@@ -162,7 +152,7 @@ private extension PreviewTestView {
             pageIndicatorLabel.leadingAnchor.constraint(equalTo: previousButton.trailingAnchor),
             pageIndicatorLabel.trailingAnchor.constraint(equalTo: nextButton.leadingAnchor),
             pageIndicatorLabel.centerYAnchor.constraint(equalTo: previousButton.centerYAnchor),
-            pageIndicatorLabel.heightAnchor.constraint(equalToConstant: 22)
+            pageIndicatorLabel.heightAnchor.constraint(equalToConstant: 22),
         ])
     }
 }

--- a/Modules/Features/Onboarding/Sources/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
+++ b/Modules/Features/Onboarding/Sources/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
@@ -56,7 +56,6 @@ final class PreviewTestViewController: UIViewController {
         super.viewDidLoad()
         bind()
         setNavigationItem()
-        setOptionActions()
         setButtonActions()
         setAlertButtonActions()
         input.send(.viewDidLoad)
@@ -80,15 +79,14 @@ private extension PreviewTestViewController {
             .sink { [weak self] event in
                 guard let self else { return }
                 switch event {
-                case .updateQuestion(let question, let curNum, let selectedOption):
-                    updateQuestionUI(question: question, curNum: curNum, selectedOption: selectedOption)
+                case .updateQuestion(let question, let selectedOption):
+                    updateQuestionUI(question: question, selectedOption: selectedOption)
                 case .updateTotalNum(let num):
                     totalNum = num
                 case .updateTime(let timeLimit, let timeRemaining):
-                    previewTestView.progressView.progress = Float(timeRemaining) / Float(timeLimit)
-                    previewTestView.timeLabel.text = timeRemaining.formattedTime
+                    previewTestView.updateProgress(timeLimit: timeLimit, timeRemaining: timeRemaining)
                 case .updateOptionState(let idx, let isSelected):
-                    setOptionState(idx: idx, isSelected: isSelected)
+                    previewTestView.updateOptionState(at: idx, isSelected: isSelected)
                 case .updateButtonStates(let prevHidden, let nextHidden, let nextTitle):
                     previewTestView.previousButton.isHidden = prevHidden
                     previewTestView.nextButton.isHidden = nextHidden
@@ -107,6 +105,10 @@ private extension PreviewTestViewController {
                     onNavigateToHome()
                 }
             }
+            .store(in: &cancellables)
+
+        previewTestView.optionTappedPublisher
+            .sink { [weak self] idx in self?.input.send(.optionTapped(idx)) }
             .store(in: &cancellables)
     }
 
@@ -132,53 +134,11 @@ private extension PreviewTestViewController {
         )
     }
 
-    func updateQuestionUI(question: PreviewTestListQuestion, curNum: Int, selectedOption: Int?) {
-        previewTestView.questionNumberLabel.text = String(format: "%02d.", curNum)
-        previewTestView.questionTitleLabel.attributedText = NSAttributedString(text: question.question, lineSpacing: 4)
-        setOptionsString(question.options.map(\.content))
-        resetOptionStates()
-        if let selectedOption { setOptionState(idx: selectedOption, isSelected: true) }
-        previewTestView.pageIndicatorLabel.setCurrentPage(curNum)
+    func updateQuestionUI(question: QuestionData, selectedOption: Int?) {
+        previewTestView.updateQuestion(question)
+        if let selectedOption { previewTestView.updateOptionState(at: selectedOption, isSelected: true) }
+        previewTestView.pageIndicatorLabel.setCurrentPage(question.questionNumber)
         previewTestView.pageIndicatorLabel.setTotalPage(totalNum)
-    }
-}
-
-// MARK: - Options
-
-private extension PreviewTestViewController {
-
-    func setOptionsString(_ options: [String]) {
-        zip(previewTestView.optionLabels, options).forEach { label, content in
-            label.setOptionString(content)
-        }
-    }
-
-    func resetOptionStates() {
-        previewTestView.optionLabels.forEach { $0.setOptionState(isSelected: false) }
-    }
-
-    func setOptionActions() {
-        for (index, optionLabel) in previewTestView.optionLabels.enumerated() {
-            optionLabel.isUserInteractionEnabled = true
-            optionLabel.tag = index + 1
-            optionLabel.addGestureRecognizer(
-                UITapGestureRecognizer(target: self, action: #selector(didTapOption(_:)))
-            )
-        }
-    }
-
-    @objc func didTapOption(_ sender: UITapGestureRecognizer) {
-        guard let idx = sender.view?.tag else { return }
-        input.send(.optionTapped(idx))
-    }
-
-    func setOptionState(idx: Int, isSelected: Bool) {
-        switch idx {
-        case 1...4:
-            previewTestView.optionLabels[idx - 1].setOptionState(isSelected: isSelected)
-        default:
-            assertionFailure("Invalid option index: \(idx)")
-        }
     }
 }
 

--- a/Modules/Features/Onboarding/Sources/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
+++ b/Modules/Features/Onboarding/Sources/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
@@ -66,11 +66,6 @@ final class PreviewTestViewController: UIViewController {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(false, animated: animated)
     }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        navigationController?.setNavigationBarHidden(true, animated: animated)
-    }
 }
 
 // MARK: - Bind

--- a/Modules/Features/Onboarding/Sources/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
+++ b/Modules/Features/Onboarding/Sources/Onboarding/PreviewTest/ViewController/PreviewTestViewController.swift
@@ -61,6 +61,16 @@ final class PreviewTestViewController: UIViewController {
         setAlertButtonActions()
         input.send(.viewDidLoad)
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: animated)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: animated)
+    }
 }
 
 // MARK: - Bind
@@ -106,7 +116,6 @@ private extension PreviewTestViewController {
     }
 
     func setNavigationItem() {
-        navigationController?.navigationBar.isHidden = false
         previewTestView.cancelButton.addAction(UIAction { [weak self] _ in
             self?.input.send(.escapeTapped)
         }, for: .touchUpInside)

--- a/Modules/Features/Onboarding/Sources/Onboarding/PreviewTest/ViewModel/PreviewTestViewModel.swift
+++ b/Modules/Features/Onboarding/Sources/Onboarding/PreviewTest/ViewModel/PreviewTestViewModel.swift
@@ -26,7 +26,7 @@ final class PreviewTestViewModel {
     }
 
     enum Output {
-        case updateQuestion(question: PreviewTestListQuestion, curNum: Int, selectedOption: Int?)
+        case updateQuestion(question: QuestionData, selectedOption: Int?)
         case updateTotalNum(Int)
         case updateTime(timeLimit: Int, timeRemaining: Int)
         case updateOptionState(idx: Int, isSelected: Bool)
@@ -137,8 +137,7 @@ private extension PreviewTestViewModel {
         let selectedOption = questions[currentIndex].selectedOptionIdx
 
         output.send(.updateQuestion(
-            question: questions[currentIndex].data,
-            curNum: currentIndex + 1,
+            question: toQuestionData(from: questions[currentIndex].data, questionNumber: currentIndex + 1),
             selectedOption: selectedOption
         ))
         sendButtonStates(index: currentIndex, selectedOption: selectedOption)
@@ -164,7 +163,7 @@ private extension PreviewTestViewModel {
             questions = rawQuestions.map { PreviewQuestion(data: $0) }
 
             output.send(.updateTotalNum(rawQuestions.count))
-            output.send(.updateQuestion(question: questions[0].data, curNum: 1, selectedOption: nil))
+            output.send(.updateQuestion(question: toQuestionData(from: questions[0].data, questionNumber: 1), selectedOption: nil))
             sendButtonStates(index: 0, selectedOption: nil)
 
             let totalTimeLimit = response.data.totalTimeLimit
@@ -185,6 +184,20 @@ private extension PreviewTestViewModel {
         } catch {
             output.send(.showError("문제 불러오기 실패"))
         }
+    }
+
+    func toQuestionData(from question: PreviewTestListQuestion, questionNumber: Int) -> QuestionData {
+        QuestionData(
+            question: question.question,
+            option1: question.options[0].content,
+            option2: question.options[1].content,
+            option3: question.options[2].content,
+            option4: question.options[3].content,
+            timeLimit: question.timeLimit,
+            questionNumber: questionNumber,
+            description: question.description,
+            skillId: question.skillId
+        )
     }
 
     func submit() async {

--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		B14DF4E72F7652D1002F6177 /* Daily in Frameworks */ = {isa = PBXBuildFile; productRef = B14DF4E62F7652D1002F6177 /* Daily */; };
 		B17C0EC52F5AACD200C8219A /* Account in Frameworks */ = {isa = PBXBuildFile; productRef = B17C0EC42F5AACD200C8219A /* Account */; };
 		B18CDE662F45AD2A00CB3AB4 /* QRIZUtils in Frameworks */ = {isa = PBXBuildFile; productRef = B18CDE652F45AD2A00CB3AB4 /* QRIZUtils */; };
+		0A324B4B8A914F5EA2863B85 /* AnalyticsServiceImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E475CE9FBD3489798BF0A58 /* AnalyticsServiceImpl.swift */; };
 		B19C4FC52D6C226500CD008A /* TabBarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B19C4FC42D6C226500CD008A /* TabBarCoordinator.swift */; };
 		B1BDD0C72F4D26CD00834D57 /* DesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = B1BDD0C62F4D26CD00834D57 /* DesignSystem */; };
 		B1BDD0CA2F4D2A5200834D57 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B1BDD0C82F4D2A5200834D57 /* Assets.xcassets */; };
@@ -34,6 +35,7 @@
 		B1004A992EC77C66000E4DE2 /* QRIZ.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = QRIZ.entitlements; sourceTree = "<group>"; };
 		B13774AC2ED9D7AF001A614D /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		B14441402F7FAEBE000C3292 /* QRIZ.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = QRIZ.xctestplan; sourceTree = "<group>"; };
+		1E475CE9FBD3489798BF0A58 /* AnalyticsServiceImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsServiceImpl.swift; sourceTree = "<group>"; };
 		B19C4FC42D6C226500CD008A /* TabBarCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarCoordinator.swift; sourceTree = "<group>"; };
 		B1BDD0C82F4D2A5200834D57 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B1D813792D768D9B00A9D447 /* AppCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
@@ -164,6 +166,14 @@
 			path = SupportingFiles;
 			sourceTree = "<group>";
 		};
+		AD15A98404AC40C1B033C972 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				1E475CE9FBD3489798BF0A58 /* AnalyticsServiceImpl.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
 		B19C4FC32D6C223E00CD008A /* TabBar */ = {
 			isa = PBXGroup;
 			children = (
@@ -215,6 +225,7 @@
 				54DB0D952D094FAA00ABD458 /* App */,
 				54DB0D962D09506C00ABD458 /* Feature */,
 				B1D813782D768D3D00A9D447 /* Coordinator */,
+				AD15A98404AC40C1B033C972 /* Utils */,
 				B1BDD0C92F4D2A5200834D57 /* Resources */,
 				54DB0DA32D09524E00ABD458 /* SupportingFiles */,
 			);
@@ -325,6 +336,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0A324B4B8A914F5EA2863B85 /* AnalyticsServiceImpl.swift in Sources */,
 				B1D8137A2D768D9B00A9D447 /* AppCoordinator.swift in Sources */,
 				E23963092D083B900092B39B /* AppDelegate.swift in Sources */,
 				B19C4FC52D6C226500CD008A /* TabBarCoordinator.swift in Sources */,

--- a/QRIZ.xcodeproj/project.pbxproj
+++ b/QRIZ.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0A324B4B8A914F5EA2863B85 /* AnalyticsServiceImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E475CE9FBD3489798BF0A58 /* AnalyticsServiceImpl.swift */; };
 		2F7A758592D8472A94299C4B /* Onboarding in Frameworks */ = {isa = PBXBuildFile; productRef = E9849FEE34F04512AEA4EBE2 /* Onboarding */; };
 		A1B2C3D52F60000200AAAAAA /* MyPage in Frameworks */ = {isa = PBXBuildFile; productRef = A1B2C3D62F60000300AAAAAA /* MyPage */; };
 		B12FEEEE2F46F98200280847 /* Network in Frameworks */ = {isa = PBXBuildFile; productRef = B12FEEED2F46F98200280847 /* Network */; };
@@ -18,7 +19,6 @@
 		B14DF4E72F7652D1002F6177 /* Daily in Frameworks */ = {isa = PBXBuildFile; productRef = B14DF4E62F7652D1002F6177 /* Daily */; };
 		B17C0EC52F5AACD200C8219A /* Account in Frameworks */ = {isa = PBXBuildFile; productRef = B17C0EC42F5AACD200C8219A /* Account */; };
 		B18CDE662F45AD2A00CB3AB4 /* QRIZUtils in Frameworks */ = {isa = PBXBuildFile; productRef = B18CDE652F45AD2A00CB3AB4 /* QRIZUtils */; };
-		0A324B4B8A914F5EA2863B85 /* AnalyticsServiceImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E475CE9FBD3489798BF0A58 /* AnalyticsServiceImpl.swift */; };
 		B19C4FC52D6C226500CD008A /* TabBarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B19C4FC42D6C226500CD008A /* TabBarCoordinator.swift */; };
 		B1BDD0C72F4D26CD00834D57 /* DesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = B1BDD0C62F4D26CD00834D57 /* DesignSystem */; };
 		B1BDD0CA2F4D2A5200834D57 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B1BDD0C82F4D2A5200834D57 /* Assets.xcassets */; };
@@ -32,10 +32,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1E475CE9FBD3489798BF0A58 /* AnalyticsServiceImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsServiceImpl.swift; sourceTree = "<group>"; };
 		B1004A992EC77C66000E4DE2 /* QRIZ.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = QRIZ.entitlements; sourceTree = "<group>"; };
 		B13774AC2ED9D7AF001A614D /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		B14441402F7FAEBE000C3292 /* QRIZ.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = QRIZ.xctestplan; sourceTree = "<group>"; };
-		1E475CE9FBD3489798BF0A58 /* AnalyticsServiceImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsServiceImpl.swift; sourceTree = "<group>"; };
 		B19C4FC42D6C226500CD008A /* TabBarCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarCoordinator.swift; sourceTree = "<group>"; };
 		B1BDD0C82F4D2A5200834D57 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B1D813792D768D9B00A9D447 /* AppCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };

--- a/QRIZ/App/AppDelegate.swift
+++ b/QRIZ/App/AppDelegate.swift
@@ -8,12 +8,14 @@
 import UIKit
 import FirebaseCore
 import Auth
+import QRIZUtils
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         FirebaseApp.configure()
+        AnalyticsManager.shared.configure(service: AnalyticsServiceImpl())
 
         let appKey = Bundle.main.object(forInfoDictionaryKey: "KAKAO_NATIVE_APP_KEY") as? String ?? ""
         AuthSDKConfigurator.configure(kakaoAppKey: appKey)

--- a/QRIZ/Feature/TabBar/TabBarCoordinator.swift
+++ b/QRIZ/Feature/TabBar/TabBarCoordinator.swift
@@ -198,6 +198,7 @@ final class TabBarCoordinatorImpl: TabBarCoordinator {
     }
     
     func logout() {
+        AnalyticsManager.shared.log(.logout)
         delegate?.didLogout(self)
     }
 }

--- a/QRIZ/Utils/AnalyticsServiceImpl.swift
+++ b/QRIZ/Utils/AnalyticsServiceImpl.swift
@@ -1,0 +1,51 @@
+//
+//  AnalyticsServiceImpl.swift
+//  QRIZ
+//
+//  Created by 김세훈 on 4/5/26.
+//
+
+import FirebaseAnalytics
+import QRIZUtils
+
+final class AnalyticsServiceImpl: AnalyticsService, @unchecked Sendable {
+
+    func log(_ event: AnalyticsEvent) {
+        switch event {
+        case .screenView(let name):
+            Analytics.logEvent(AnalyticsEventScreenView, parameters: [
+                AnalyticsParameterScreenName: name.rawValue
+            ])
+
+        case .login(let method):
+            Analytics.logEvent(AnalyticsEventLogin, parameters: [
+                AnalyticsParameterMethod: method.rawValue
+            ])
+
+        case .logout:
+            Analytics.logEvent("logout", parameters: nil)
+
+        case .examStart:
+            Analytics.logEvent("exam_start", parameters: nil)
+
+        case .examComplete(let score, let total):
+            Analytics.logEvent("exam_complete", parameters: [
+                "score": score,
+                "total": total
+            ])
+
+        case .examAbandon:
+            Analytics.logEvent("exam_abandon", parameters: nil)
+
+        case .dailyComplete:
+            Analytics.logEvent("daily_complete", parameters: nil)
+
+        case .apiError(let endpoint, let statusCode, let message):
+            Analytics.logEvent("api_error", parameters: [
+                "endpoint": endpoint,
+                "status_code": statusCode,
+                "error_message": message
+            ])
+        }
+    }
+}


### PR DESCRIPTION
## 🛠️ Task
- Firebase Analytics 연동
- CheckConceptView UI 개선 및 DesignSystem 체크박스 아이콘 적용
- 온보딩 → 메인 진입 시 탭바/네비게이션 바 표시 처리
- ExamList 진입 시 탭바 숨김 처리
- QuestionOptionLabel UI 및 탭 제스처 개선
- TestContentsView UI 구조 개선 및 코드 정리
- PreviewTest에 TestContentsView 적용 및 코드 정리
- AnalyticsManager.shared Swift 6 actor isolation 오류 수정
- 카카오 회원탈퇴 iOS SDK unlink 제거 (백엔드 Admin API 위임)
- logoutKakao SDK 실패 시에도 서버 로그아웃 진행

## 🌱 PR Point
### PreviewTest에 TestContentsView 적용
ExamTest, DailyTest와 동일한 TestContentsView를 PreviewTest에 적용했습니다.
기존 PreviewTestView에서 문제/선택지를 직접 그리던 중복 레이아웃 코드를 제거하고 공유 컴포넌트로 통일했습니다.

### 카카오 회원탈퇴 플로우 수정
카카오 SDK unlinkKakao() 호출이 토큰 만료 등의 상황에서 실패하면 회원탈퇴 전체가 중단되는 문제가 있었습니다. iOS에서 SDK unlink를 직접 호출하는 대신 백엔드가 Admin API로 처리하도록 역할을 분리해 이 문제를 해결했습니다.

### logoutKakao 개선
서버 RT 삭제가 핵심 동작이므로 Kakao SDK 로그아웃은 try?로 best-effort 처리해 SDK 실패 여부와 관계없이 서버 로그아웃이 항상 실행되도록 수정했습니다.

## 📮 Issue 번호
- resolved: #129 
