### PR TITLE
FEAT: 선택지 UI 가독성 개선

### DIFF
--- a/Modules/Core/ExamKit/Sources/ExamKit/QuestionUI/QuestionOptionLabel.swift
+++ b/Modules/Core/ExamKit/Sources/ExamKit/QuestionUI/QuestionOptionLabel.swift
@@ -22,7 +22,7 @@ public final class QuestionOptionLabel: UIView {
 
     private let optionStringLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 16, weight: .regular)
+        label.font = .monospacedSystemFont(ofSize: 16, weight: .regular)
         label.textColor = .coolNeutral800
         label.numberOfLines = 0
         return label
@@ -53,7 +53,10 @@ public final class QuestionOptionLabel: UIView {
         layer.borderWidth = 1
     }
 
-    public func setOptionString(_ str: String) {
+    public func setOptionString(_ str: String, contentType: String = "TEXT") {
+        optionStringLabel.font = contentType == "SQL"
+            ? .monospacedSystemFont(ofSize: 13, weight: .regular)
+            : .systemFont(ofSize: 16, weight: .regular)
         optionStringLabel.attributedText = NSAttributedString(text: str, lineSpacing: 6)
     }
 

--- a/Modules/Core/ExamKit/Sources/ExamKit/QuestionUI/TestContentsView.swift
+++ b/Modules/Core/ExamKit/Sources/ExamKit/QuestionUI/TestContentsView.swift
@@ -97,7 +97,8 @@ public final class TestContentsView: UIView {
         descriptionLabel.attributedText = question.description.map { NSAttributedString(text: $0, lineSpacing: 4) }
         optionLabels.enumerated().forEach { index, label in
             label.setOptionState(isSelected: false)
-            label.setOptionString(question.getOptionRawValue(option: index + 1))
+            let contentType = question.optionContentTypes.indices.contains(index) ? question.optionContentTypes[index] : "TEXT"
+            label.setOptionString(question.getOptionRawValue(option: index + 1), contentType: contentType)
         }
     }
 

--- a/Modules/Core/Network/Sources/Network/DTOs/Daily/DailyTestListRequest.swift
+++ b/Modules/Core/Network/Sources/Network/DTOs/Daily/DailyTestListRequest.swift
@@ -47,5 +47,6 @@ public struct DailyTestInfo: Decodable, Sendable {
     public struct OptionInfo: Decodable, Sendable {
         public let id: Int
         public let content: String
+        public let contentType: String
     }
 }

--- a/Modules/Core/Network/Sources/Network/DTOs/Exam/ExamQuestionRequest.swift
+++ b/Modules/Core/Network/Sources/Network/DTOs/Exam/ExamQuestionRequest.swift
@@ -83,10 +83,12 @@ public struct ExamQuestionInfo: Decodable, Sendable {
     public struct OptionInfo: Decodable, Sendable {
         public let id: Int
         public let content: String
+        public let contentType: String
 
-        public init(id: Int, content: String) {
+        public init(id: Int, content: String, contentType: String) {
             self.id = id
             self.content = content
+            self.contentType = contentType
         }
     }
 }

--- a/Modules/Core/Network/Sources/Network/DTOs/Onboarding/PreviewTestListRequest.swift
+++ b/Modules/Core/Network/Sources/Network/DTOs/Onboarding/PreviewTestListRequest.swift
@@ -64,8 +64,9 @@ public struct PreviewTestListQuestion: Decodable, Sendable {
 public struct PreviewTestListOption: Decodable, Sendable {
     public let id: Int
     public let content: String
+    public let contentType: String
 
-    public init(id: Int, content: String) {
-        self.id = id; self.content = content
+    public init(id: Int, content: String, contentType: String) {
+        self.id = id; self.content = content; self.contentType = contentType
     }
 }

--- a/Modules/Core/QRIZUtils/Sources/QRIZUtils/Model/TestModel/QuestionData.swift
+++ b/Modules/Core/QRIZUtils/Sources/QRIZUtils/Model/TestModel/QuestionData.swift
@@ -11,18 +11,20 @@ public struct QuestionData: Sendable {
     public var option2: String
     public var option3: String
     public var option4: String
+    public var optionContentTypes: [String]
     public var timeLimit: Int
     public var questionNumber: Int
     public var selectedOption: Int? = nil
     public var description: String? = nil
     public var skillId: Int? = nil
 
-    public init(question: String, option1: String, option2: String, option3: String, option4: String, timeLimit: Int, questionNumber: Int, selectedOption: Int? = nil, description: String? = nil, skillId: Int? = nil) {
+    public init(question: String, option1: String, option2: String, option3: String, option4: String, optionContentTypes: [String] = ["TEXT", "TEXT", "TEXT", "TEXT"], timeLimit: Int, questionNumber: Int, selectedOption: Int? = nil, description: String? = nil, skillId: Int? = nil) {
         self.question = question
         self.option1 = option1
         self.option2 = option2
         self.option3 = option3
         self.option4 = option4
+        self.optionContentTypes = optionContentTypes
         self.timeLimit = timeLimit
         self.questionNumber = questionNumber
         self.selectedOption = selectedOption

--- a/Modules/Features/Daily/Sources/Daily/DailyTest/ViewModel/DailyTestViewModel.swift
+++ b/Modules/Features/Daily/Sources/Daily/DailyTest/ViewModel/DailyTestViewModel.swift
@@ -120,6 +120,7 @@ final class DailyTestViewModel {
                         option2: item.options[1].content,
                         option3: item.options[2].content,
                         option4: item.options[3].content,
+                        optionContentTypes: item.options.map { $0.contentType },
                         timeLimit: item.timeLimit,
                         questionNumber: index + 1,
                         description: item.description

--- a/Modules/Features/Exam/Sources/Exam/ExamTest/ViewModel/ExamTestViewModel.swift
+++ b/Modules/Features/Exam/Sources/Exam/ExamTest/ViewModel/ExamTestViewModel.swift
@@ -93,6 +93,7 @@ final class ExamTestViewModel {
                         option2: question.options[1].content,
                         option3: question.options[2].content,
                         option4: question.options[3].content,
+                        optionContentTypes: question.options.map { $0.contentType },
                         timeLimit: question.timeLimit,
                         questionNumber: index + 1,
                         description: question.description

--- a/Modules/Features/Onboarding/Sources/Onboarding/PreviewTest/ViewModel/PreviewTestViewModel.swift
+++ b/Modules/Features/Onboarding/Sources/Onboarding/PreviewTest/ViewModel/PreviewTestViewModel.swift
@@ -193,6 +193,7 @@ private extension PreviewTestViewModel {
             option2: question.options[1].content,
             option3: question.options[2].content,
             option4: question.options[3].content,
+            optionContentTypes: question.options.map { $0.contentType },
             timeLimit: question.timeLimit,
             questionNumber: questionNumber,
             description: question.description,


### PR DESCRIPTION
## 🛠️ Task

- TEXT / SQL 구분용 contentType 필드 추가
- contentType에 따라 선택지 폰트 분기 처리

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| TestContetnsView | <img width="300" height="670" alt="image" src="https://github.com/user-attachments/assets/7b576604-5a23-4ef4-b3fb-5d13ef7f18e2" /> |

## 📮 Issue 번호
- resolved: #132 
