### PR TITLE
FIX: 프리뷰 테스트 API 응답 디코딩 오류 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,4 @@ Packages/*/.build/
 ### Claude Code ###
 .claude/
 CLAUDE.md
-docs/superpowers/plans/
+docs/superpowers/

--- a/Modules/Core/Network/Sources/Network/DTOs/Onboarding/PreviewTestListRequest.swift
+++ b/Modules/Core/Network/Sources/Network/DTOs/Onboarding/PreviewTestListRequest.swift
@@ -66,7 +66,18 @@ public struct PreviewTestListOption: Decodable, Sendable {
     public let content: String
     public let contentType: String
 
-    public init(id: Int, content: String, contentType: String) {
+    public init(id: Int, content: String, contentType: String = "TEXT") {
         self.id = id; self.content = content; self.contentType = contentType
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(Int.self, forKey: .id)
+        content = try container.decode(String.self, forKey: .content)
+        contentType = try container.decodeIfPresent(String.self, forKey: .contentType) ?? "TEXT"
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, content, contentType
     }
 }


### PR DESCRIPTION
## 🛠️ Task

- `PreviewTestListOption` 커스텀 `Decodable` 이니셜라이저 추가
- `contentType` 필드 누락 시 기본값 `"TEXT"` 처리

## 📮 Issue 번호
- resolved: #136