### PR TITLE
REFACTOR: ProblemDetail을 ExamKit으로 이동해 Feature 간 직접 의존 제거

### DIFF
--- a/Modules/Core/ExamKit/Package.swift
+++ b/Modules/Core/ExamKit/Package.swift
@@ -10,12 +10,13 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../../Core/DesignSystem"),
-        .package(path: "../../Core/QRIZUtils")
+        .package(path: "../../Core/QRIZUtils"),
+        .package(path: "../../Core/QRIZNetwork")
     ],
     targets: [
         .target(
             name: "ExamKit",
-            dependencies: ["DesignSystem", "QRIZUtils"]
+            dependencies: ["DesignSystem", "QRIZUtils", "QRIZNetwork"]
         ),
         .testTarget(
             name: "ExamKitTests",

--- a/Modules/Core/ExamKit/Sources/ExamKit/ProblemDetail/View/ProblemDetailView.swift
+++ b/Modules/Core/ExamKit/Sources/ExamKit/ProblemDetail/View/ProblemDetailView.swift
@@ -1,6 +1,6 @@
 //
 //  ProblemDetailView.swift
-//  MistakeNote
+//  ExamKit
 //
 //  Created by Claude on 12/30/25.
 //
@@ -123,16 +123,3 @@ private extension ProblemDetailView {
     }
 }
 
-// MARK: - Preview
-
-#Preview {
-    NavigationView {
-        ProblemDetailView(
-            viewModel: ProblemDetailViewModel {
-                let service = DailyServiceImpl()
-                let response = try await service.getDailyResultDetail(dayNumber: 1, questionId: 1)
-                return response.data.toEntity()
-            }
-        )
-    }
-}

--- a/Modules/Core/ExamKit/Sources/ExamKit/ProblemDetail/View/ProblemHeaderCardView.swift
+++ b/Modules/Core/ExamKit/Sources/ExamKit/ProblemDetail/View/ProblemHeaderCardView.swift
@@ -1,6 +1,6 @@
 //
 //  ProblemHeaderCardView.swift
-//  MistakeNote
+//  ExamKit
 //
 //  Created by Claude on 12/30/25.
 //

--- a/Modules/Core/ExamKit/Sources/ExamKit/ProblemDetail/View/ProblemKeyConceptsView.swift
+++ b/Modules/Core/ExamKit/Sources/ExamKit/ProblemDetail/View/ProblemKeyConceptsView.swift
@@ -1,6 +1,6 @@
 //
 //  ProblemKeyConceptsView.swift
-//  MistakeNote
+//  ExamKit
 //
 //  Created by Claude on 1/2/26.
 //

--- a/Modules/Core/ExamKit/Sources/ExamKit/ProblemDetail/View/ProblemOptionView.swift
+++ b/Modules/Core/ExamKit/Sources/ExamKit/ProblemDetail/View/ProblemOptionView.swift
@@ -1,6 +1,6 @@
 //
 //  ProblemOptionView.swift
-//  MistakeNote
+//  ExamKit
 //
 //  Created by Claude on 12/30/25.
 //

--- a/Modules/Core/ExamKit/Sources/ExamKit/ProblemDetail/View/ProblemQuestionSectionView.swift
+++ b/Modules/Core/ExamKit/Sources/ExamKit/ProblemDetail/View/ProblemQuestionSectionView.swift
@@ -1,6 +1,6 @@
 //
 //  ProblemQuestionSectionView.swift
-//  MistakeNote
+//  ExamKit
 //
 //  Created by Claude on 12/30/25.
 //

--- a/Modules/Core/ExamKit/Sources/ExamKit/ProblemDetail/View/ProblemResultView.swift
+++ b/Modules/Core/ExamKit/Sources/ExamKit/ProblemDetail/View/ProblemResultView.swift
@@ -1,6 +1,6 @@
 //
 //  ProblemResultView.swift
-//  MistakeNote
+//  ExamKit
 //
 //  Created by Claude on 12/31/25.
 //

--- a/Modules/Core/ExamKit/Sources/ExamKit/ProblemDetail/View/ProblemSolutionView.swift
+++ b/Modules/Core/ExamKit/Sources/ExamKit/ProblemDetail/View/ProblemSolutionView.swift
@@ -1,6 +1,6 @@
 //
 //  ProblemSolutionView.swift
-//  MistakeNote
+//  ExamKit
 //
 //  Created by Claude on 12/31/25.
 //

--- a/Modules/Core/ExamKit/Sources/ExamKit/ProblemDetail/ViewController/ProblemDetailViewController.swift
+++ b/Modules/Core/ExamKit/Sources/ExamKit/ProblemDetail/ViewController/ProblemDetailViewController.swift
@@ -1,6 +1,6 @@
 //
 //  ProblemDetailViewController.swift
-//  MistakeNote
+//  ExamKit
 //
 //  Created by Claude on 12/30/25.
 //

--- a/Modules/Core/ExamKit/Sources/ExamKit/ProblemDetail/ViewModel/ProblemDetailViewModel.swift
+++ b/Modules/Core/ExamKit/Sources/ExamKit/ProblemDetail/ViewModel/ProblemDetailViewModel.swift
@@ -1,6 +1,6 @@
 //
 //  ProblemDetailViewModel.swift
-//  MistakeNote
+//  ExamKit
 //
 //  Created by Claude on 1/3/26.
 //

--- a/Modules/Features/Daily/Package.swift
+++ b/Modules/Features/Daily/Package.swift
@@ -14,7 +14,6 @@ let package = Package(
         .package(path: "../../Core/QRIZUtils"),
         .package(path: "../ExamKit"),
         .package(path: "../Conceptbook"),
-        .package(path: "../MistakeNote"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.9"),
     ],
     targets: [
@@ -26,7 +25,6 @@ let package = Package(
                 "QRIZUtils",
                 "ExamKit",
                 "Conceptbook",
-                "MistakeNote",
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v5)

--- a/Modules/Features/Daily/Sources/Daily/Coordinator/DailyCoordinatorImpl.swift
+++ b/Modules/Features/Daily/Sources/Daily/Coordinator/DailyCoordinatorImpl.swift
@@ -4,7 +4,6 @@ import QRIZUtils
 import QRIZNetwork
 import ExamKit
 import Conceptbook
-import MistakeNote
 
 @MainActor
 final class DailyCoordinatorImpl: DailyNavigating, NavigationGuard {

--- a/Modules/Features/Exam/Package.swift
+++ b/Modules/Features/Exam/Package.swift
@@ -14,7 +14,6 @@ let package = Package(
         .package(path: "../../Core/QRIZUtils"),
         .package(path: "../ExamKit"),
         .package(path: "../Conceptbook"),
-        .package(path: "../MistakeNote"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.9"),
     ],
     targets: [
@@ -26,7 +25,6 @@ let package = Package(
                 "QRIZUtils",
                 "ExamKit",
                 "Conceptbook",
-                "MistakeNote",
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v5)

--- a/Modules/Features/Exam/Sources/Exam/Coordinator/ExamCoordinatorImpl.swift
+++ b/Modules/Features/Exam/Sources/Exam/Coordinator/ExamCoordinatorImpl.swift
@@ -4,7 +4,6 @@ import QRIZUtils
 import QRIZNetwork
 import ExamKit
 import Conceptbook
-import MistakeNote
 
 @MainActor
 final class ExamCoordinatorImpl: ExamNavigating, NavigationGuard {

--- a/Modules/Features/MistakeNote/Package.swift
+++ b/Modules/Features/MistakeNote/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
         .package(path: "../../Core/QRIZNetwork"),
         .package(path: "../../Core/DesignSystem"),
         .package(path: "../../Core/QRIZUtils"),
+        .package(path: "../../Core/ExamKit"),
         .package(path: "../Conceptbook"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.9"),
     ],
@@ -22,6 +23,7 @@ let package = Package(
                 "QRIZNetwork",
                 "DesignSystem",
                 "QRIZUtils",
+                "ExamKit",
                 "Conceptbook",
             ]
         ),

--- a/Modules/Features/MistakeNote/Sources/MistakeNote/Coordinator/MistakeNoteCoordinator.swift
+++ b/Modules/Features/MistakeNote/Sources/MistakeNote/Coordinator/MistakeNoteCoordinator.swift
@@ -8,6 +8,7 @@
 import UIKit
 import QRIZUtils
 import QRIZNetwork
+import ExamKit
 import Conceptbook
 
 @MainActor


### PR DESCRIPTION
## 관련 이슈

closes #147 

## 변경 사항

모듈화 이후 Daily, Exam이 문제 해설 화면을 위해 MistakeNote(Feature)를 직접 import하고 있었습니다.

`ProblemDetailViewModel`, `ProblemDetailViewController`, `ProblemDetailCoordinating` 3개 컴포넌트를 MistakeNote에서 ExamKit(Core)으로 이동해 Feature 간 직접 의존을 제거했습니다.

**변경 전**
```
Daily → ExamKit, MistakeNote, Conceptbook
Exam  → ExamKit, MistakeNote, Conceptbook
```

**변경 후**
```
Daily → ExamKit, Conceptbook
Exam  → ExamKit, Conceptbook
MistakeNote → ExamKit, Conceptbook
```

## 변경 파일

- `Modules/Core/ExamKit/Package.swift` — QRIZNetwork 의존 추가
- `Modules/Core/ExamKit/Sources/ExamKit/ProblemDetail/` — ProblemDetail 컴포넌트 이동
- `Modules/Features/MistakeNote/Package.swift` — ExamKit 의존 추가
- `Modules/Features/MistakeNote/.../MistakeNoteCoordinator.swift` — import ExamKit 추가
- `Modules/Features/Daily/Package.swift` — MistakeNote 의존 제거
- `Modules/Features/Daily/.../DailyCoordinatorImpl.swift` — import MistakeNote 제거
- `Modules/Features/Exam/Package.swift` — MistakeNote 의존 제거
- `Modules/Features/Exam/.../ExamCoordinatorImpl.swift` — import MistakeNote 제거

## 참고

Daily/Exam → Conceptbook, MistakeNote → Conceptbook 의존은 별도 이슈에서 처리합니다.