### PR TITLE
REFACTOR: Coordinator delegate 패턴으로 Feature → Conceptbook 직접 의존 제거

### DIFF
--- a/Modules/Features/Daily/Package.swift
+++ b/Modules/Features/Daily/Package.swift
@@ -13,7 +13,6 @@ let package = Package(
         .package(path: "../../Core/DesignSystem"),
         .package(path: "../../Core/QRIZUtils"),
         .package(path: "../ExamKit"),
-        .package(path: "../Conceptbook"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.9"),
     ],
     targets: [
@@ -24,7 +23,6 @@ let package = Package(
                 "DesignSystem",
                 "QRIZUtils",
                 "ExamKit",
-                "Conceptbook",
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v5)

--- a/Modules/Features/Daily/Sources/Daily/Coordinator/DailyCoordinator.swift
+++ b/Modules/Features/Daily/Sources/Daily/Coordinator/DailyCoordinator.swift
@@ -13,6 +13,7 @@ public protocol DailyCoordinator: Coordinator {
 public protocol DailyCoordinatorDelegate: AnyObject {
     func didQuitDaily(_ coordinator: any DailyCoordinator)
     func moveFromDailyToConcept(_ coordinator: any DailyCoordinator)
+    func conceptPDFViewController(chapter: Chapter, conceptItem: ConceptItem) -> UIViewController
 }
 
 @MainActor

--- a/Modules/Features/Daily/Sources/Daily/Coordinator/DailyCoordinatorImpl.swift
+++ b/Modules/Features/Daily/Sources/Daily/Coordinator/DailyCoordinatorImpl.swift
@@ -3,7 +3,6 @@ import SwiftUI
 import QRIZUtils
 import QRIZNetwork
 import ExamKit
-import Conceptbook
 
 @MainActor
 final class DailyCoordinatorImpl: DailyNavigating, NavigationGuard {
@@ -65,8 +64,8 @@ final class DailyCoordinatorImpl: DailyNavigating, NavigationGuard {
     }
 
     func showConcept(chapter: Chapter, conceptItem: ConceptItem) {
+        guard let vc = delegate?.conceptPDFViewController(chapter: chapter, conceptItem: conceptItem) else { return }
         guardNavigation {
-            let vc = makeConceptPDFViewController(chapter: chapter, conceptItem: conceptItem)
             self.navigationController.pushViewController(vc, animated: true)
         }
     }

--- a/Modules/Features/Exam/Package.swift
+++ b/Modules/Features/Exam/Package.swift
@@ -13,7 +13,6 @@ let package = Package(
         .package(path: "../../Core/DesignSystem"),
         .package(path: "../../Core/QRIZUtils"),
         .package(path: "../ExamKit"),
-        .package(path: "../Conceptbook"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.9"),
     ],
     targets: [
@@ -24,7 +23,6 @@ let package = Package(
                 "DesignSystem",
                 "QRIZUtils",
                 "ExamKit",
-                "Conceptbook",
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v5)

--- a/Modules/Features/Exam/Sources/Exam/Coordinator/ExamCoordinator.swift
+++ b/Modules/Features/Exam/Sources/Exam/Coordinator/ExamCoordinator.swift
@@ -13,6 +13,7 @@ public protocol ExamCoordinator: Coordinator {
 public protocol ExamCoordinatorDelegate: AnyObject {
     func didQuitExam(_ coordinator: any ExamCoordinator)
     func moveFromExamToConcept(_ coordinator: any ExamCoordinator)
+    func conceptPDFViewController(chapter: Chapter, conceptItem: ConceptItem) -> UIViewController
 }
 
 @MainActor

--- a/Modules/Features/Exam/Sources/Exam/Coordinator/ExamCoordinatorImpl.swift
+++ b/Modules/Features/Exam/Sources/Exam/Coordinator/ExamCoordinatorImpl.swift
@@ -3,7 +3,6 @@ import SwiftUI
 import QRIZUtils
 import QRIZNetwork
 import ExamKit
-import Conceptbook
 
 @MainActor
 final class ExamCoordinatorImpl: ExamNavigating, NavigationGuard {
@@ -104,8 +103,8 @@ final class ExamCoordinatorImpl: ExamNavigating, NavigationGuard {
     }
 
     func showConcept(chapter: Chapter, conceptItem: ConceptItem) {
+        guard let vc = delegate?.conceptPDFViewController(chapter: chapter, conceptItem: conceptItem) else { return }
         guardNavigation {
-            let vc = makeConceptPDFViewController(chapter: chapter, conceptItem: conceptItem)
             self.navigationController.pushViewController(vc, animated: true)
         }
     }

--- a/Modules/Features/Home/Sources/Home/Coordinator/HomeCoordinatorImpl.swift
+++ b/Modules/Features/Home/Sources/Home/Coordinator/HomeCoordinatorImpl.swift
@@ -262,6 +262,10 @@ extension HomeCoordinatorImpl: ExamCoordinatorDelegate {
         navigationController?.popToRootViewController(animated: true)
         delegate?.moveToConcept()
     }
+
+    func conceptPDFViewController(chapter: Chapter, conceptItem: ConceptItem) -> UIViewController {
+        makeConceptPDFViewController(chapter: chapter, conceptItem: conceptItem)
+    }
 }
 
 // MARK: - DailyCoordinatorDelegate

--- a/Modules/Features/MistakeNote/Package.swift
+++ b/Modules/Features/MistakeNote/Package.swift
@@ -13,7 +13,6 @@ let package = Package(
         .package(path: "../../Core/DesignSystem"),
         .package(path: "../../Core/QRIZUtils"),
         .package(path: "../../Core/ExamKit"),
-        .package(path: "../Conceptbook"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.18.9"),
     ],
     targets: [
@@ -24,7 +23,6 @@ let package = Package(
                 "DesignSystem",
                 "QRIZUtils",
                 "ExamKit",
-                "Conceptbook",
             ]
         ),
         .testTarget(

--- a/Modules/Features/MistakeNote/Sources/MistakeNote/Coordinator/MistakeNoteCoordinator.swift
+++ b/Modules/Features/MistakeNote/Sources/MistakeNote/Coordinator/MistakeNoteCoordinator.swift
@@ -9,7 +9,6 @@ import UIKit
 import QRIZUtils
 import QRIZNetwork
 import ExamKit
-import Conceptbook
 
 @MainActor
 public protocol MistakeNoteCoordinator: Coordinator {
@@ -21,6 +20,7 @@ public protocol MistakeNoteCoordinator: Coordinator {
 public protocol MistakeNoteCoordinatorDelegate: AnyObject {
     func moveFromMistakeNoteToConcept(_ coordinator: MistakeNoteCoordinator)
     func moveFromMistakeNoteToExam(_ coordinator: MistakeNoteCoordinator, tab: MistakeNoteTab)
+    func conceptPDFViewController(chapter: Chapter, conceptItem: ConceptItem) -> UIViewController
 }
 
 @MainActor
@@ -72,8 +72,8 @@ public final class MistakeNoteCoordinatorImpl: MistakeNoteCoordinator, Navigatio
     }
 
     private func showConcept(chapter: Chapter, conceptItem: ConceptItem) {
+        guard let vc = delegate?.conceptPDFViewController(chapter: chapter, conceptItem: conceptItem) else { return }
         guardNavigation {
-            let vc = makeConceptPDFViewController(chapter: chapter, conceptItem: conceptItem)
             navigationController?.pushViewController(vc, animated: true)
         }
     }

--- a/QRIZ/Feature/TabBar/TabBarCoordinator.swift
+++ b/QRIZ/Feature/TabBar/TabBarCoordinator.swift
@@ -270,6 +270,10 @@ extension TabBarCoordinatorImpl: MistakeNoteCoordinatorDelegate {
             }
         )
     }
+
+    func conceptPDFViewController(chapter: Chapter, conceptItem: ConceptItem) -> UIViewController {
+        makeConceptPDFViewController(chapter: chapter, conceptItem: conceptItem)
+    }
 }
 
 // MARK: - MyPageCoordinatorDelegate


### PR DESCRIPTION
## 관련 이슈

Closes #149

## 변경 사항

Daily, Exam, MistakeNote 모듈이 `makeConceptPDFViewController` 호출을 위해 Feature 모듈인 Conceptbook을 직접 import하던 구조를 제거한다.

### 문제

```
Daily     → Conceptbook (Feature)  ← Feature-to-Feature 직접 의존
Exam      → Conceptbook (Feature)  ← Feature-to-Feature 직접 의존
MistakeNote → Conceptbook (Feature) ← Feature-to-Feature 직접 의존
```

### 해결: Coordinator delegate factory 패턴

각 Coordinator delegate 프로토콜에 `conceptPDFViewController(chapter:conceptItem:) -> UIViewController` 메서드를 추가한다. Daily/Exam/MistakeNote Coordinator는 ViewController 생성을 delegate에 위임하고, Conceptbook을 알고 있는 상위 Coordinator(HomeCoordinatorImpl, TabBarCoordinatorImpl)가 이를 구현한다.

```
After:
Daily     → ExamKit (Core)   ← Conceptbook 제거
Exam      → ExamKit (Core)   ← Conceptbook 제거
MistakeNote → QRIZUtils      ← Conceptbook 제거
```

### 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `Daily/DailyCoordinator.swift` | `conceptPDFViewController` delegate 메서드 추가 |
| `Daily/DailyCoordinatorImpl.swift` | `import Conceptbook` 제거, delegate 호출로 변경 |
| `Daily/Package.swift` | Conceptbook 의존 제거 |
| `Exam/ExamCoordinator.swift` | `conceptPDFViewController` delegate 메서드 추가 |
| `Exam/ExamCoordinatorImpl.swift` | `import Conceptbook` 제거, delegate 호출로 변경 |
| `Exam/Package.swift` | Conceptbook 의존 제거 |
| `MistakeNote/MistakeNoteCoordinator.swift` | `conceptPDFViewController` delegate 메서드 추가, `import Conceptbook` 제거 |
| `MistakeNote/Package.swift` | Conceptbook 의존 제거 |
| `Home/HomeCoordinatorImpl.swift` | `conceptPDFViewController` 구현 (Exam + Daily delegate) |
| `TabBar/TabBarCoordinator.swift` | `conceptPDFViewController` 구현 (MistakeNote delegate) |

## 테스트 체크리스트

- [ ] Daily → 문제 해설 → 개념 확인 화면 진입
- [ ] Exam → 문제 해설 → 개념 확인 화면 진입
- [ ] MistakeNote → 오답 → 개념 확인 화면 진입

🤖 Generated with [Claude Code](https://claude.ai/claude-code)