### PR TITLE
REFACTOR: Interface 패키지에서 QRIZNetwork 의존 제거

### DIFF
--- a/Modules/Features/Daily/Sources/Daily/Coordinator/DailyCoordinator.swift
+++ b/Modules/Features/Daily/Sources/Daily/Coordinator/DailyCoordinator.swift
@@ -23,12 +23,15 @@ public func makeDailyCoordinator(
 }
 
 public struct DefaultDailyCoordinatorFactory: DailyCoordinatorFactory {
-    public init() {}
+    private let dailyService: any DailyService
+
+    public init(dailyService: any DailyService) {
+        self.dailyService = dailyService
+    }
 
     @MainActor
     public func makeDailyCoordinator(
         navigationController: UINavigationController,
-        dailyService: any DailyService,
         day: Int,
         type: DailyLearnType,
         adService: any AdService

--- a/Modules/Features/DailyInterface/Package.swift
+++ b/Modules/Features/DailyInterface/Package.swift
@@ -10,12 +10,11 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../../Core/QRIZUtils"),
-        .package(path: "../../Core/QRIZNetwork"),
     ],
     targets: [
         .target(
             name: "DailyInterface",
-            dependencies: ["QRIZUtils", "QRIZNetwork"]
+            dependencies: ["QRIZUtils"]
         ),
     ]
 )

--- a/Modules/Features/DailyInterface/Sources/DailyInterface/DailyCoordinating.swift
+++ b/Modules/Features/DailyInterface/Sources/DailyInterface/DailyCoordinating.swift
@@ -1,6 +1,5 @@
 import UIKit
 import QRIZUtils
-import QRIZNetwork
 
 @MainActor
 public protocol DailyCoordinator: Coordinator {
@@ -18,7 +17,6 @@ public protocol DailyCoordinatorDelegate: AnyObject {
 public protocol DailyCoordinatorFactory {
     func makeDailyCoordinator(
         navigationController: UINavigationController,
-        dailyService: any DailyService,
         day: Int,
         type: DailyLearnType,
         adService: any AdService

--- a/Modules/Features/Exam/Sources/Exam/Coordinator/ExamCoordinator.swift
+++ b/Modules/Features/Exam/Sources/Exam/Coordinator/ExamCoordinator.swift
@@ -15,12 +15,15 @@ public func makeExamCoordinator(
 }
 
 public struct DefaultExamCoordinatorFactory: ExamCoordinatorFactory {
-    public init() {}
+    private let examService: any ExamService
+
+    public init(examService: any ExamService) {
+        self.examService = examService
+    }
 
     @MainActor
     public func makeExamCoordinator(
         navigationController: UINavigationController,
-        examService: any ExamService,
         adService: any AdService
     ) -> any ExamCoordinator {
         ExamCoordinatorImpl(navigationController: navigationController, examService: examService, adService: adService)

--- a/Modules/Features/ExamInterface/Package.swift
+++ b/Modules/Features/ExamInterface/Package.swift
@@ -10,12 +10,11 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../../Core/QRIZUtils"),
-        .package(path: "../../Core/QRIZNetwork"),
     ],
     targets: [
         .target(
             name: "ExamInterface",
-            dependencies: ["QRIZUtils", "QRIZNetwork"]
+            dependencies: ["QRIZUtils"]
         ),
     ]
 )

--- a/Modules/Features/ExamInterface/Sources/ExamInterface/ExamCoordinating.swift
+++ b/Modules/Features/ExamInterface/Sources/ExamInterface/ExamCoordinating.swift
@@ -1,6 +1,5 @@
 import UIKit
 import QRIZUtils
-import QRIZNetwork
 
 @MainActor
 public protocol ExamCoordinator: Coordinator {
@@ -18,7 +17,6 @@ public protocol ExamCoordinatorDelegate: AnyObject {
 public protocol ExamCoordinatorFactory {
     func makeExamCoordinator(
         navigationController: UINavigationController,
-        examService: any ExamService,
         adService: any AdService
     ) -> any ExamCoordinator
 }

--- a/Modules/Features/Home/Sources/Home/Coordinator/HomeCoordinator.swift
+++ b/Modules/Features/Home/Sources/Home/Coordinator/HomeCoordinator.swift
@@ -38,10 +38,7 @@ public protocol HomeCoordinatorDelegate: AnyObject {
 @MainActor
 public func makeHomeCoordinator(
     examService: any ExamScheduleService,
-    examTestService: any ExamService,
     dailyService: any DailyService,
-    onboardingService: any OnboardingService,
-    userInfoService: any UserInfoService,
     weeklyService: any WeeklyRecommendService,
     adService: any AdService,
     dailyFactory: any DailyCoordinatorFactory,
@@ -51,10 +48,7 @@ public func makeHomeCoordinator(
 ) -> any HomeCoordinator {
     HomeCoordinatorImpl(
         examService: examService,
-        examTestService: examTestService,
         dailyService: dailyService,
-        onboardingService: onboardingService,
-        userInfoService: userInfoService,
         weeklyService: weeklyService,
         adService: adService,
         dailyFactory: dailyFactory,

--- a/Modules/Features/Home/Sources/Home/Coordinator/HomeCoordinatorImpl.swift
+++ b/Modules/Features/Home/Sources/Home/Coordinator/HomeCoordinatorImpl.swift
@@ -16,10 +16,7 @@ final class HomeCoordinatorImpl: HomeCoordinator, NavigationGuard {
     weak var examDelegate: (any ExamSelectionDelegate)?
     private(set) weak var navigationController: UINavigationController?
     private let examService: ExamScheduleService
-    private let examTestService: ExamService
     private let dailyService: DailyService
-    private let onboardingService: OnboardingService
-    private let userInfoService: UserInfoService
     private let weeklyService: WeeklyRecommendService
     private let adService: any AdService
     private let dailyFactory: any DailyCoordinatorFactory
@@ -36,10 +33,7 @@ final class HomeCoordinatorImpl: HomeCoordinator, NavigationGuard {
 
     init(
         examService: ExamScheduleService,
-        examTestService: ExamService,
         dailyService: DailyService,
-        onboardingService: OnboardingService,
-        userInfoService: UserInfoService,
         weeklyService: WeeklyRecommendService,
         adService: any AdService,
         dailyFactory: any DailyCoordinatorFactory,
@@ -48,10 +42,7 @@ final class HomeCoordinatorImpl: HomeCoordinator, NavigationGuard {
         conceptbookFactory: any ConceptbookFactory
     ) {
         self.examService = examService
-        self.examTestService = examTestService
         self.dailyService = dailyService
-        self.onboardingService = onboardingService
-        self.userInfoService = userInfoService
         self.weeklyService = weeklyService
         self.adService = adService
         self.dailyFactory = dailyFactory
@@ -122,10 +113,7 @@ final class HomeCoordinatorImpl: HomeCoordinator, NavigationGuard {
         guard let navi = navigationController else { return }
         guardNavigation {
             let onboarding = self.onboardingFactory.makeOnboardingCoordinator(
-                navigationController: navi,
-                onboardingService: self.onboardingService,
-                userInfoService: self.userInfoService,
-                dailyService: self.dailyService
+                navigationController: navi
             )
             onboarding.delegate = self
             self.onboardingCoordinator = onboarding
@@ -139,7 +127,6 @@ final class HomeCoordinatorImpl: HomeCoordinator, NavigationGuard {
         guardNavigation {
             let exam = self.examFactory.makeExamCoordinator(
                 navigationController: navi,
-                examService: self.examTestService,
                 adService: self.adService
             )
             exam.delegate = self
@@ -153,7 +140,6 @@ final class HomeCoordinatorImpl: HomeCoordinator, NavigationGuard {
         guardNavigation {
             let daily = self.dailyFactory.makeDailyCoordinator(
                 navigationController: navi,
-                dailyService: self.dailyService,
                 day: day,
                 type: type,
                 adService: self.adService

--- a/Modules/Features/Onboarding/Sources/Onboarding/Coordinator/OnboardingCoordinator.swift
+++ b/Modules/Features/Onboarding/Sources/Onboarding/Coordinator/OnboardingCoordinator.swift
@@ -21,14 +21,23 @@ public func makeOnboardingCoordinator(
 }
 
 public struct DefaultOnboardingCoordinatorFactory: OnboardingCoordinatorFactory {
-    public init() {}
+    private let onboardingService: OnboardingService
+    private let userInfoService: UserInfoService
+    private let dailyService: any DailyService
 
-    @MainActor
-    public func makeOnboardingCoordinator(
-        navigationController: UINavigationController,
+    public init(
         onboardingService: OnboardingService,
         userInfoService: UserInfoService,
         dailyService: any DailyService
+    ) {
+        self.onboardingService = onboardingService
+        self.userInfoService = userInfoService
+        self.dailyService = dailyService
+    }
+
+    @MainActor
+    public func makeOnboardingCoordinator(
+        navigationController: UINavigationController
     ) -> any OnboardingCoordinator {
         OnboardingCoordinatorImpl(
             navigationController: navigationController,

--- a/Modules/Features/OnboardingInterface/Package.swift
+++ b/Modules/Features/OnboardingInterface/Package.swift
@@ -10,12 +10,11 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../../Core/QRIZUtils"),
-        .package(path: "../../Core/QRIZNetwork"),
     ],
     targets: [
         .target(
             name: "OnboardingInterface",
-            dependencies: ["QRIZUtils", "QRIZNetwork"]
+            dependencies: ["QRIZUtils"]
         ),
     ]
 )

--- a/Modules/Features/OnboardingInterface/Sources/OnboardingInterface/OnboardingCoordinating.swift
+++ b/Modules/Features/OnboardingInterface/Sources/OnboardingInterface/OnboardingCoordinating.swift
@@ -1,6 +1,5 @@
 import UIKit
 import QRIZUtils
-import QRIZNetwork
 
 @MainActor
 public protocol OnboardingCoordinator: Coordinator {
@@ -15,9 +14,6 @@ public protocol OnboardingCoordinatorDelegate: AnyObject {
 @MainActor
 public protocol OnboardingCoordinatorFactory {
     func makeOnboardingCoordinator(
-        navigationController: UINavigationController,
-        onboardingService: OnboardingService,
-        userInfoService: UserInfoService,
-        dailyService: any DailyService
+        navigationController: UINavigationController
     ) -> any OnboardingCoordinator
 }

--- a/QRIZ/Feature/TabBar/TabBarCoordinator.swift
+++ b/QRIZ/Feature/TabBar/TabBarCoordinator.swift
@@ -53,15 +53,16 @@ final class TabBarCoordinatorDependencyImpl: TabBarCoordinatorDependency {
 
     private lazy var _homeCoordinator = makeHomeCoordinator(
         examService: examService,
-        examTestService: examTestService,
         dailyService: dailyService,
-        onboardingService: onboardingService,
-        userInfoService: userInfoService,
         weeklyService: weeklyService,
         adService: adService,
-        dailyFactory: DefaultDailyCoordinatorFactory(),
-        examFactory: DefaultExamCoordinatorFactory(),
-        onboardingFactory: DefaultOnboardingCoordinatorFactory(),
+        dailyFactory: DefaultDailyCoordinatorFactory(dailyService: dailyService),
+        examFactory: DefaultExamCoordinatorFactory(examService: examTestService),
+        onboardingFactory: DefaultOnboardingCoordinatorFactory(
+            onboardingService: onboardingService,
+            userInfoService: userInfoService,
+            dailyService: dailyService
+        ),
         conceptbookFactory: DefaultConceptbookFactory()
     )
     


### PR DESCRIPTION
## 관련 이슈

Closes #153

## 문제

PR #152에서 Interface 패키지(DailyInterface, ExamInterface, OnboardingInterface)를 만들 때 팩토리 프로토콜의 메서드 파라미터로 `DailyService`, `ExamService` 등 서비스 타입을 받고 있었습니다. 이 타입들은 QRIZNetwork에 정의돼 있어서 Interface 패키지가 QRIZNetwork를 의존해야 했고, Home이 Interface만 바라보도록 분리한 의미가 반감됐습니다. 인터페이스 경계 밖으로 구현 세부사항인 서비스 타입이 새나오는 추상화 누수 문제였습니다.

## 접근

팩토리 프로토콜의 역할을 다시 생각해봤습니다. 팩토리가 `makeXxxCoordinator(service:)` 처럼 서비스를 파라미터로 받는 구조는, 호출자(Home)가 서비스를 알고 있어야 한다는 뜻입니다. Home이 서비스 타입을 알면 Interface 분리의 의미가 없습니다.

대신 `DefaultXxxFactory`가 서비스를 init에서 캡처하도록 바꿨습니다. 팩토리 생성 책임은 App 레이어(TabBarCoordinator)로 넘기고, Home은 팩토리 인터페이스만 보면 됩니다. Interface 패키지에서 QRIZNetwork 의존을 완전히 끊을 수 있습니다.

## 변경사항

### Interface 패키지 3개 — QRIZNetwork 의존 제거

`DailyInterface`, `ExamInterface`, `OnboardingInterface`의 `Package.swift`에서 QRIZNetwork 의존을 제거하고, 팩토리 프로토콜 메서드 시그니처에서 서비스 파라미터를 삭제했습니다.

### DefaultXxxFactory — 서비스 init 캡처

`DefaultDailyCoordinatorFactory`, `DefaultExamCoordinatorFactory`, `DefaultOnboardingCoordinatorFactory` 각각이 서비스를 init에서 받아 저장하도록 변경했습니다.

### HomeCoordinatorImpl — 불필요해진 프로퍼티 제거

팩토리 이관으로 Home이 더 이상 필요 없게 된 `examTestService`, `onboardingService`, `userInfoService` 프로퍼티와 init 파라미터를 제거했습니다. `makeHomeCoordinator` 시그니처도 함께 정리했습니다.

### App 레이어 — 서비스 주입 책임 흡수

`TabBarCoordinator`에서 `DefaultXxxFactory` 생성 시 서비스를 주입합니다. 구체 타입을 아는 건 App 레이어 하나뿐입니다.

## 효과

- Interface 패키지가 QRIZUtils만 의존하게 되어 진정한 인터페이스 경계가 만들어졌습니다.
- Home은 서비스 타입을 전혀 알 필요가 없습니다. 팩토리 프로토콜만 주입받으면 됩니다.
- 서비스 구체 타입 연결 책임이 App 레이어로 완전히 집중됐습니다 (Composition Root 패턴).

## 테스트 체크리스트

- [x] 홈 → Daily 학습 진입
- [x] 홈 → 모의고사 진입
- [x] 홈 → 온보딩 진입 (최초 사용자)
- [x] 빌드 성공