### PR TITLE
FEAT: 데일리 테스트 제출 API 중복 방지 submissionId 추가

### DIFF
--- a/Modules/Core/QRIZNetwork/Sources/Network/DTOs/Daily/DailySubmitRequest.swift
+++ b/Modules/Core/QRIZNetwork/Sources/Network/DTOs/Daily/DailySubmitRequest.swift
@@ -9,34 +9,39 @@ import QRIZUtils
 
 public struct DailySubmitRequest: Request, Sendable {
     public typealias Response = DailySubmitResponse
-    
+
     public let method: HTTPMethod = .post
     private let accessToken: String
     private let dayNumber: Int
+    private let submissionId: String
     private let dailySubmitData: [DailySubmitData]
-    
+
     public var path: String {
         "/api/v1/daily/submit/\(dayNumber)"
     }
-    
+
     public var body: Encodable? {
-        [
-            "activities": dailySubmitData
-        ]
+        DailySubmitBody(submissionId: submissionId, activities: dailySubmitData)
     }
-    
+
     public var headers: HTTPHeader {
         [
             HTTPHeaderField.contentType.rawValue: ContentType.json.rawValue,
             HTTPHeaderField.authorization.rawValue: accessToken
         ]
     }
-    
-    public init(accessToken: String, dayNumber: Int, dailySubmitData: [DailySubmitData]) {
+
+    public init(accessToken: String, dayNumber: Int, submissionId: String, dailySubmitData: [DailySubmitData]) {
         self.accessToken = accessToken
         self.dayNumber = dayNumber
+        self.submissionId = submissionId
         self.dailySubmitData = dailySubmitData
     }
+}
+
+private struct DailySubmitBody: Encodable {
+    let submissionId: String
+    let activities: [DailySubmitData]
 }
 
 public struct DailySubmitResponse: Decodable, Sendable {

--- a/Modules/Core/QRIZNetwork/Sources/Network/Service/Daily/DailyService.swift
+++ b/Modules/Core/QRIZNetwork/Sources/Network/Service/Daily/DailyService.swift
@@ -13,7 +13,7 @@ public protocol DailyService {
     
     func getDailyTestList(dayNumber: Int) async throws -> DailyTestListResponse
     
-    func submitDaily(dayNumber: Int, dailySubmitData: [DailySubmitData]) async throws
+    func submitDaily(dayNumber: Int, submissionId: String, dailySubmitData: [DailySubmitData]) async throws
     
     func getDailyTestResult(dayNumber: Int) async throws -> DailyResultResponse
     
@@ -58,8 +58,13 @@ public final class DailyServiceImpl: DailyService {
         return try await network.send(request)
     }
     
-    public func submitDaily(dayNumber: Int, dailySubmitData: [DailySubmitData]) async throws {
-        let request = DailySubmitRequest(accessToken: getAccessToken(), dayNumber: dayNumber, dailySubmitData: dailySubmitData)
+    public func submitDaily(dayNumber: Int, submissionId: String, dailySubmitData: [DailySubmitData]) async throws {
+        let request = DailySubmitRequest(
+            accessToken: getAccessToken(),
+            dayNumber: dayNumber,
+            submissionId: submissionId,
+            dailySubmitData: dailySubmitData
+        )
         _ = try await network.send(request)
     }
     

--- a/Modules/Features/Daily/Sources/Daily/DailyTest/ViewModel/DailyTestViewModel.swift
+++ b/Modules/Features/Daily/Sources/Daily/DailyTest/ViewModel/DailyTestViewModel.swift
@@ -47,6 +47,7 @@ final class DailyTestViewModel {
     private var submitData: [DailySubmitData] = []
     private var dailyTestList: [DailyTestInfo] = []
     private var curNum: Int?
+    private var submissionId: String?
     private var timer: Timer?
     private var timeLimit: Int?
     private var startTime: Date?
@@ -207,10 +208,18 @@ final class DailyTestViewModel {
     }
     
     private func sendSubmitData() {
+        if submissionId == nil {
+            submissionId = UUID().uuidString
+        }
+        guard let submissionId else { return }
         Task { [weak self] in
             guard let self else { return }
             do {
-                try await dailyService.submitDaily(dayNumber: day, dailySubmitData: submitData)
+                try await dailyService.submitDaily(
+                    dayNumber: day,
+                    submissionId: submissionId,
+                    dailySubmitData: submitData
+                )
                 exitTimer()
                 analyticsService.log(.dailyComplete)
                 output.send(.submitSuccess)

--- a/Modules/Features/Daily/Tests/DailyTests/Mocks/MockDailyService.swift
+++ b/Modules/Features/Daily/Tests/DailyTests/Mocks/MockDailyService.swift
@@ -32,12 +32,14 @@ final class MockDailyService: DailyService {
     )
     var submitDailyResult: Result<Void, Error> = .success(())
     var capturedSubmitData: [DailySubmitData]?
+    var capturedSubmissionId: String?
 
     func getDailyTestList(dayNumber: Int) async throws -> DailyTestListResponse {
         try getDailyTestListResult.get()
     }
 
-    func submitDaily(dayNumber: Int, dailySubmitData: [DailySubmitData]) async throws {
+    func submitDaily(dayNumber: Int, submissionId: String, dailySubmitData: [DailySubmitData]) async throws {
+        capturedSubmissionId = submissionId
         capturedSubmitData = dailySubmitData
         try submitDailyResult.get()
     }

--- a/Modules/Features/Daily/Tests/DailyTests/UnitTests/DailyTestViewModelTests.swift
+++ b/Modules/Features/Daily/Tests/DailyTests/UnitTests/DailyTestViewModelTests.swift
@@ -255,6 +255,45 @@ struct DailyTestViewModelTests {
         #expect(harness.service.capturedSubmitData?[0].optionId == 12)
     }
 
+    // MARK: - submissionId
+
+    @Test("첫 제출 시 UUID가 생성되어 서비스에 전달됨")
+    func submit_firstAttempt_generatesAndPassesUUID() async throws {
+        let harness = TestHarness(service: MockDailyService())
+        try await harness.sendViewDidLoad()
+        harness.send(.nextButtonClicked)
+        harness.send(.nextButtonClicked)
+        harness.send(.nextButtonClicked) // popSubmitAlert
+        harness.send(.alertSubmitButtonClicked)
+        try? await Task.sleep(nanoseconds: asyncSleepNanoseconds)
+        let submissionId = harness.service.capturedSubmissionId
+        #expect(submissionId != nil)
+        #expect(submissionId?.isEmpty == false)
+    }
+
+    @Test("재시도 시 동일 UUID가 재사용됨")
+    func submit_retry_reusesSameUUID() async throws {
+        let service = MockDailyService()
+        service.submitDailyResult = .failure(URLError(.notConnectedToInternet))
+        let harness = TestHarness(service: service)
+        try await harness.sendViewDidLoad()
+        harness.send(.nextButtonClicked)
+        harness.send(.nextButtonClicked)
+        harness.send(.nextButtonClicked)
+
+        harness.send(.alertSubmitButtonClicked) // 1차 시도 (실패)
+        try? await Task.sleep(nanoseconds: asyncSleepNanoseconds)
+        let firstId = harness.service.capturedSubmissionId
+
+        service.submitDailyResult = .success(())
+        harness.send(.alertSubmitButtonClicked) // 2차 시도 (성공)
+        try? await Task.sleep(nanoseconds: asyncSleepNanoseconds)
+        let secondId = harness.service.capturedSubmissionId
+
+        #expect(firstId != nil)
+        #expect(firstId == secondId)
+    }
+
     @Test("얼럿 취소 버튼 → cancelAlert emit")
     func alertCancel_emitsCancelAlert() {
         let harness = TestHarness(service: MockDailyService())

--- a/Modules/Features/Home/Tests/HomeTests/Mocks/MockDailyService.swift
+++ b/Modules/Features/Home/Tests/HomeTests/Mocks/MockDailyService.swift
@@ -31,7 +31,7 @@ final class MockDailyService: DailyService {
         throw NSError(domain: "MockDailyService", code: -1, userInfo: [NSLocalizedDescriptionKey: "not implemented"])
     }
 
-    func submitDaily(dayNumber: Int, dailySubmitData: [DailySubmitData]) async throws {
+    func submitDaily(dayNumber: Int, submissionId: String, dailySubmitData: [DailySubmitData]) async throws {
         throw NSError(domain: "MockDailyService", code: -1, userInfo: [NSLocalizedDescriptionKey: "not implemented"])
     }
 

--- a/Modules/Features/MistakeNote/Package.swift
+++ b/Modules/Features/MistakeNote/Package.swift
@@ -31,6 +31,7 @@ let package = Package(
                 "MistakeNote",
                 "QRIZNetwork",
                 "QRIZUtils",
+                "ExamKit",
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
             ]
         ),

--- a/Modules/Features/MistakeNote/Tests/MistakeNoteTests/SnapshotTests/ProblemDetailSnapshotTests.swift
+++ b/Modules/Features/MistakeNote/Tests/MistakeNoteTests/SnapshotTests/ProblemDetailSnapshotTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import SnapshotTesting
 @testable import MistakeNote
+@testable import ExamKit
 
 @MainActor
 class ProblemDetailSnapshotTests: MistakeNoteSnapshotTestCase {

--- a/Modules/Features/MistakeNote/Tests/MistakeNoteTests/UnitTests/ProblemDetailViewModelTests.swift
+++ b/Modules/Features/MistakeNote/Tests/MistakeNoteTests/UnitTests/ProblemDetailViewModelTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import Foundation
 @testable import MistakeNote
+@testable import ExamKit
 import QRIZUtils
 
 @MainActor

--- a/Modules/Features/Onboarding/Sources/Onboarding/PlanDurationSelection/View/PlanDurationSelectionView.swift
+++ b/Modules/Features/Onboarding/Sources/Onboarding/PlanDurationSelection/View/PlanDurationSelectionView.swift
@@ -80,7 +80,7 @@ private extension PlanDurationSelectionView {
 private struct PreviewDailyService: DailyService {
     func getDailyDetailAndStatus(dayNumber: Int) async throws -> DailyDetailAndStatusResponse { fatalError() }
     func getDailyTestList(dayNumber: Int) async throws -> DailyTestListResponse { fatalError() }
-    func submitDaily(dayNumber: Int, dailySubmitData: [DailySubmitData]) async throws { fatalError() }
+    func submitDaily(dayNumber: Int, submissionId: String, dailySubmitData: [DailySubmitData]) async throws { fatalError() }
     func getDailyTestResult(dayNumber: Int) async throws -> DailyResultResponse { fatalError() }
     func getDailyWeeklyScore(dayNumber: Int) async throws -> DailyWeeklyScoreResponse { fatalError() }
     func getDailyPlan() async throws -> DailyPlanResponse { fatalError() }

--- a/Modules/Features/Onboarding/Tests/OnboardingTests/Mocks/MockDailyService.swift
+++ b/Modules/Features/Onboarding/Tests/OnboardingTests/Mocks/MockDailyService.swift
@@ -21,7 +21,7 @@ final class MockDailyService: DailyService {
     func getDailyTestList(dayNumber: Int) async throws -> DailyTestListResponse {
         throw NSError(domain: "MockDailyService", code: -1)
     }
-    func submitDaily(dayNumber: Int, dailySubmitData: [DailySubmitData]) async throws {
+    func submitDaily(dayNumber: Int, submissionId: String, dailySubmitData: [DailySubmitData]) async throws {
         throw NSError(domain: "MockDailyService", code: -1)
     }
     func getDailyTestResult(dayNumber: Int) async throws -> DailyResultResponse {


### PR DESCRIPTION
## 관련 이슈

Closes #155

## 문제

3월 초에 특정 유저의 데일리 테스트 제출이 12,000회 이상 중복 INSERT되는 이슈가 있었습니다. 네트워크 레벨 자동 재시도가 원인으로 추정됩니다. 서버에서 멱등성 키 방어 로직을 추가했지만, 클라이언트가 `submissionId`를 함께 보내야 실제로 동작합니다.

## 접근

UUID를 어디서 생성할지가 핵심이었습니다.

- **Request DTO에서 생성하면** — 재시도마다 새 UUID가 만들어져 동일 제출로 인식이 안 됩니다.
- **Service에서 보관하면** — Service가 상태를 갖게 되고, 여러 화면에서 공유되는 Service 특성상 어느 세션의 UUID인지 구분이 어렵습니다.
- **ViewModel에서 보관하는 방식을 선택했습니다.** "첫 제출이면 생성, 재시도면 재사용"이라는 판단은 비즈니스 로직이고 ViewModel이 이미 제출에 필요한 모든 상태를 갖고 있습니다. 또한 ViewModel 생명주기 = 제출 세션 생명주기이므로, 재시험은 새 인스턴스가 생성되어 UUID가 자동으로 분리됩니다.

## 변경사항

### `DailySubmitRequest` — body 구조체 교체

기존 딕셔너리 리터럴 `["activities": ...]`를 `DailySubmitBody` 구조체로 교체해 `submissionId`와 `activities`를 함께 인코딩합니다.

### `DailyService` — 시그니처 변경

`submitDaily(dayNumber:dailySubmitData:)` → `submitDaily(dayNumber:submissionId:dailySubmitData:)`

### `DailyTestViewModel` — UUID 생성·보관·재사용

`submissionId: String?` 프로퍼티를 추가하고, `sendSubmitData()` 진입 시 nil이면 새 UUID를 생성·저장, 이미 있으면 재사용합니다.

### Mock/Preview 5곳 — 프로토콜 변경 추종

`Daily`, `Home`, `Onboarding`의 `MockDailyService`와 Onboarding의 `PreviewDailyService` stub을 업데이트했습니다. Daily Mock에는 테스트 검증용 `capturedSubmissionId` 프로퍼티를 추가했습니다.

### `MistakeNote` — 기존 빌드 오류 수정

`ProblemDetailViewModel`이 `ExamKit`으로 이동된 이후 `MistakeNoteTests`가 빌드되지 않는 문제가 있었습니다. `Package.swift`에 `ExamKit` 테스트 의존성을 추가하고 해당 테스트 파일에 import를 추가했습니다.

## 효과

- 서버 멱등성 키가 실제로 동작해 네트워크 재시도로 인한 중복 제출이 방지됩니다.
- 재시험은 별도 ViewModel 인스턴스이므로 1회차와 2회차 UUID가 자연스럽게 분리됩니다.
- 서버는 관대 모드로 배포 예정이므로 이 PR 없이도 기존 동작이 유지됩니다.

## 테스트 체크리스트

- [x] 데일리 테스트 정상 제출 → 콘솔에 `[DailySubmit] 새 submissionId 생성` 출력
- [x] 네트워크 실패 후 재시도 → `[DailySubmit] 기존 submissionId 재사용` + 동일 UUID 출력
- [x] 제출 성공 → 결과 화면 정상 이동
- [x] DailyTests 전체 통과 (54개)